### PR TITLE
Remove rewriteWarn task dependsOn link to check task

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -67,15 +67,11 @@ public class RewritePlugin implements Plugin<Project> {
                 })
         );
 
-        // Warn hooks into the regular Java build by becoming a dependency of "check", the same way that checkstyle or unit tests do
         Task rewriteWarnAll = tasks.create("rewriteWarn", taskClosure(task -> {
                     task.setGroup("rewrite");
                     task.setDescription("Dry run the active refactoring recipes to all sources. No changes will be made.");
                 })
         );
-
-        Task checkTask = tasks.getByName("check");
-        checkTask.dependsOn(rewriteWarnAll);
 
         Task rewriteDiscoverAll = tasks.create("rewriteDiscover", taskClosure(task -> {
             task.setGroup("rewrite");

--- a/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
@@ -75,30 +75,6 @@ class RewritePluginTest extends RewriteTestBase {
             }
             """.stripIndent()
 
-    def "rewriteWarn task does not have dependsOn link to check task"() {
-        given:
-        projectDir.newFile("settings.gradle")
-        File rewriteYaml = projectDir.newFile("rewrite-config.yml")
-        rewriteYaml.text = rewriteYamlText
-
-        File buildGradleFile = projectDir.newFile("build.gradle")
-        buildGradleFile.text = buildGradleFileText
-
-        when:
-        def result = gradleRunner(gradleVersion, "check").build()
-
-        def rewriteWarnResult = result.task(":rewriteWarn")
-        def checkResult = result.task(":check")
-
-        then:
-        checkResult.outcome == TaskOutcome.UP_TO_DATE
-        // "rewriteWarn" task should not have been called
-        rewriteWarnResult == null
-
-        where:
-        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
-    }
-
     def "rewriteWarn task runs successfully as a standalone command without modifying source files"() {
         given:
         projectDir.newFile("settings.gradle")

--- a/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Unroll
 @Unroll
 class RewritePluginTest extends RewriteTestBase {
 
-    String rewriteYamlText =  """\
+    String rewriteYamlText = """\
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.gradle.SayHello

--- a/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
@@ -75,8 +75,31 @@ class RewritePluginTest extends RewriteTestBase {
             }
             """.stripIndent()
 
-    @Ignore
-    def "rewriteWarn task will run as part of a normal Java Build"() {
+    def "rewriteWarn task does not have dependsOn link to check task"() {
+        given:
+        projectDir.newFile("settings.gradle")
+        File rewriteYaml = projectDir.newFile("rewrite-config.yml")
+        rewriteYaml.text = rewriteYamlText
+
+        File buildGradleFile = projectDir.newFile("build.gradle")
+        buildGradleFile.text = buildGradleFileText
+
+        when:
+        def result = gradleRunner(gradleVersion, "check").build()
+
+        def rewriteWarnResult = result.task(":rewriteWarn")
+        def checkResult = result.task(":check")
+
+        then:
+        checkResult.outcome == TaskOutcome.UP_TO_DATE
+        // "rewriteWarn" task should not have been called
+        rewriteWarnResult == null
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    def "rewriteWarn task runs successfully as a standalone command without modifying source files"() {
         given:
         projectDir.newFile("settings.gradle")
         File rewriteYaml = projectDir.newFile("rewrite-config.yml")
@@ -87,11 +110,10 @@ class RewritePluginTest extends RewriteTestBase {
         File sourceFile = writeSource(HelloWorldJavaBeforeRefactor)
 
         when:
-        def result = gradleRunner(gradleVersion, "build").build()
+        def result = gradleRunner(gradleVersion, "rewriteWarn").build()
 
         def rewriteWarnMainResult = result.task(":rewriteWarnMain")
         def rewriteWarnTestResult = result.task(":rewriteWarnTest")
-
 
         then:
         rewriteWarnMainResult.outcome == TaskOutcome.SUCCESS


### PR DESCRIPTION
In order to be more discreet with usage, unlink rewriteWarn from check by default. rewriteWarn can be wired into dependsOn check through build.gradle config if desired.

May warrant docs update. May need to cross-reference with Maven plugin functionality.