### PR TITLE
rename tasks rewriteWarn to rewriteDryRun and rewriteFix to rewriteRun

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -23,11 +23,11 @@ import org.openrewrite.Result;
 
 import javax.inject.Inject;
 
-public class RewriteWarnTask extends AbstractRewriteTask {
-    private static final Logger log = Logging.getLogger(RewriteWarnTask.class);
+public class RewriteDryRunTask extends AbstractRewriteTask {
+    private static final Logger log = Logging.getLogger(RewriteDryRunTask.class);
 
     @Inject
-    public RewriteWarnTask(SourceSet sourceSet, RewriteExtension extension) {
+    public RewriteDryRunTask(SourceSet sourceSet, RewriteExtension extension) {
         super(sourceSet, extension);
         setGroup("rewrite");
         setDescription("Dry run the active refactoring recipes to sources within the " + sourceSet.getName() + " SourceSet. No results will be made.");

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -72,7 +72,7 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
                         " by:");
                 logRecipesThatMadeChanges(result);
             }
-            getLog().warn("Run 'gradle rewriteFix' to apply the fixes. Afterwards, review and commit the results.");
+            getLog().warn("Run 'gradle rewriteRun' to apply the fixes. Afterwards, review and commit the results.");
         }
     }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -65,24 +65,10 @@ public class RewritePlugin implements Plugin<Project> {
                     task.setDescription("Apply the active refactoring recipes to all sources");
                 })
         );
-        // aliasing deprecated "rewriteFix" to new "rewriteRun" task equivalent
-        Task rewriteFixAll = tasks.create("rewriteFix", taskClosure(task -> {
-                    task.setGroup("rewrite");
-                    task.setDescription("DEPRECATED: alias for rewriteRun.");
-                    task.dependsOn(rewriteRunAll);
-                })
-        );
 
         Task rewriteDryRunAll = tasks.create("rewriteDryRun", taskClosure(task -> {
                     task.setGroup("rewrite");
                     task.setDescription("Dry run the active refactoring recipes to all sources. No changes will be made.");
-                })
-        );
-        // aliasing deprecated "rewriteWarn" to new "rewriteDryRun" task equivalent
-        Task rewriteWarnAll = tasks.create("rewriteWarn", taskClosure(task -> {
-                    task.setGroup("rewrite");
-                    task.setDescription("DEPRECATED: alias for rewriteDryRun.");
-                    task.dependsOn(rewriteDryRunAll);
                 })
         );
 
@@ -98,11 +84,6 @@ public class RewritePlugin implements Plugin<Project> {
             RewriteRunTask rewriteRun = tasks.create(rewriteRunTaskName, RewriteRunTask.class, sourceSet, extension);
             rewriteRunAll.configure(taskClosure(it -> it.dependsOn(rewriteRun)));
 
-            // aliasing deprecated "rewriteFix" to new "rewriteRun" task equivalent
-            String rewriteFixTaskName = "rewriteFix" + sourceSet.getName().substring(0, 1).toUpperCase() + sourceSet.getName().substring(1);
-            Task rewriteFixTask = tasks.create(rewriteFixTaskName, taskClosure(it -> it.dependsOn(rewriteRun)));
-            rewriteFixAll.configure(taskClosure(it -> it.dependsOn(rewriteFixTask)));
-
             String rewriteDiscoverTaskName = "rewriteDiscover" + sourceSet.getName().substring(0, 1).toUpperCase() + sourceSet.getName().substring(1);
             RewriteDiscoverTask discoverTask = tasks.create(rewriteDiscoverTaskName, RewriteDiscoverTask.class, sourceSet, extension);
             rewriteDiscoverAll.dependsOn(discoverTask);
@@ -114,11 +95,6 @@ public class RewritePlugin implements Plugin<Project> {
             String rewriteDryRunTaskName = "rewriteDryRun" + sourceSet.getName().substring(0, 1).toUpperCase() + sourceSet.getName().substring(1);
             RewriteDryRunTask rewriteDryRun = tasks.create(rewriteDryRunTaskName, RewriteDryRunTask.class, sourceSet, extension);
             rewriteDryRunAll.configure(taskClosure(it -> it.dependsOn(rewriteDryRun)));
-
-            // aliasing deprecated "rewriteWarn" to new "rewriteDryRun" task equivalent
-            String rewriteWarnTaskName = "rewriteWarn" + sourceSet.getName().substring(0, 1).toUpperCase() + sourceSet.getName().substring(1);
-            Task rewriteWarnTask = tasks.create(rewriteWarnTaskName, taskClosure(it -> it.dependsOn(rewriteDryRun)));
-            rewriteWarnAll.configure(taskClosure(it -> it.dependsOn(rewriteWarnTask)));
         });
     }
 

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class RewriteFixTask extends AbstractRewriteTask {
-    private static final Logger log = Logging.getLogger(RewriteFixTask.class);
+public class RewriteRunTask extends AbstractRewriteTask {
+    private static final Logger log = Logging.getLogger(RewriteRunTask.class);
 
     @Inject
-    public RewriteFixTask(SourceSet sourceSet, RewriteExtension extension) {
+    public RewriteRunTask(SourceSet sourceSet, RewriteExtension extension) {
         super(sourceSet, extension);
         setGroup("rewrite");
         setDescription("Apply the active refactoring recipes to sources within the " + sourceSet.getName() + " SourceSet");

--- a/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
@@ -103,27 +103,6 @@ class RewritePluginTest extends RewriteTestBase {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
-    def "rewriteWarn task (deprecated) is an alias to rewriteDryRun"() {
-        given:
-        projectDir.newFile("settings.gradle")
-        File rewriteYaml = projectDir.newFile("rewrite-config.yml")
-        rewriteYaml.text = rewriteYamlText
-
-        File buildGradleFile = projectDir.newFile("build.gradle")
-        buildGradleFile.text = buildGradleFileText
-
-        when:
-        def result = gradleRunner(gradleVersion, "rewriteWarn").build()
-
-        def rewriteWarnResult = result.task(":rewriteDryRun")
-
-        then:
-        rewriteWarnResult.outcome == TaskOutcome.SUCCESS
-
-        where:
-        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
-    }
-
     def "rewriteRun will alter the source file according to the provided active recipe"() {
         given:
         projectDir.newFile("settings.gradle")
@@ -144,27 +123,6 @@ class RewritePluginTest extends RewriteTestBase {
         !sourceFileBefore.exists()
         sourceFileAfter.exists()
         sourceFileAfter.text == HelloWorldJavaAfterRefactor
-
-        where:
-        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
-    }
-
-    def "rewriteFix task (deprecated) is an alias to rewriteRun"() {
-        given:
-        projectDir.newFile("settings.gradle")
-        File rewriteYaml = projectDir.newFile("rewrite-config.yml")
-        rewriteYaml.text = rewriteYamlText
-
-        File buildGradleFile = projectDir.newFile("build.gradle")
-        buildGradleFile.text = buildGradleFileText
-
-        when:
-        def result = gradleRunner(gradleVersion, "rewriteFix").build()
-
-        def rewriteFixResult = result.task(":rewriteRun")
-
-        then:
-        rewriteFixResult.outcome == TaskOutcome.SUCCESS
 
         where:
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST

--- a/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
+++ b/plugin/src/test/groovy/org/openrewrite/gradle/RewritePluginTest.groovy
@@ -93,7 +93,7 @@ class RewritePluginTest extends RewriteTestBase {
 
         then:
         rewriteDryRunMainResult.outcome == TaskOutcome.SUCCESS
-        // The "rewriteDryRun" task should not have touched the source file and the "rewriteFix" task shouldn't have run
+        // The "rewriteDryRun" task should not have touched the source file and the "rewriteRun" task shouldn't have run
         sourceFile.text == HelloWorldJavaBeforeRefactor
         // With no test source in this project any of these are potentially reasonable results
         // Ultimately NO_SOURCE is probably the most appropriate, but in this early stage of development SUCCESS is acceptable
@@ -124,7 +124,7 @@ class RewritePluginTest extends RewriteTestBase {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
-    def "rewriteFix will alter the source file according to the provided active recipe"() {
+    def "rewriteRun will alter the source file according to the provided active recipe"() {
         given:
         projectDir.newFile("settings.gradle")
         File rewriteYaml = projectDir.newFile("rewrite-config.yml")
@@ -136,11 +136,11 @@ class RewritePluginTest extends RewriteTestBase {
         File sourceFileAfter = new File(projectDir.root, "src/main/java/org/openrewrite/after/HelloWorld.java")
 
         when:
-        def result = gradleRunner(gradleVersion, "rewriteFixMain").build()
-        def rewriteFixMainResult = result.task(":rewriteFixMain")
+        def result = gradleRunner(gradleVersion, "rewriteRunMain").build()
+        def rewriteRunMainResult = result.task(":rewriteRunMain")
 
         then:
-        rewriteFixMainResult.outcome == TaskOutcome.SUCCESS
+        rewriteRunMainResult.outcome == TaskOutcome.SUCCESS
         !sourceFileBefore.exists()
         sourceFileAfter.exists()
         sourceFileAfter.text == HelloWorldJavaAfterRefactor
@@ -149,7 +149,28 @@ class RewritePluginTest extends RewriteTestBase {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
-    def "rewriteFix applies pre-shipped AutoFormat on multi-project builds"() {
+    def "rewriteFix task (deprecated) is an alias to rewriteRun"() {
+        given:
+        projectDir.newFile("settings.gradle")
+        File rewriteYaml = projectDir.newFile("rewrite-config.yml")
+        rewriteYaml.text = rewriteYamlText
+
+        File buildGradleFile = projectDir.newFile("build.gradle")
+        buildGradleFile.text = buildGradleFileText
+
+        when:
+        def result = gradleRunner(gradleVersion, "rewriteFix").build()
+
+        def rewriteFixResult = result.task(":rewriteRun")
+
+        then:
+        rewriteFixResult.outcome == TaskOutcome.SUCCESS
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    def "rewriteRun applies pre-shipped AutoFormat on multi-project builds"() {
         // note, the "output" result of this test is at least somewhat contingent
         // on the current state of what the recipe will perform depending on the version
         // of upstream rewrite used at the time of running this test--
@@ -211,9 +232,9 @@ class RewritePluginTest extends RewriteTestBase {
                 }
             """.stripIndent()
         when:
-        def result = gradleRunner(gradleVersion, "rewriteFix").build()
-        def aRewriteFixResult = result.task(":a:rewriteFixTest")
-        def bRewriteFixResult = result.task(":b:rewriteFixTest")
+        def result = gradleRunner(gradleVersion, "rewriteRun").build()
+        def aRewriteRunResult = result.task(":a:rewriteRunTest")
+        def bRewriteRunResult = result.task(":b:rewriteRunTest")
         String aTestClassExpected = """\
                 package com.foo;
     
@@ -239,8 +260,8 @@ class RewritePluginTest extends RewriteTestBase {
                 }
         """.stripIndent()
         then:
-        aRewriteFixResult.outcome == TaskOutcome.SUCCESS
-        bRewriteFixResult.outcome == TaskOutcome.SUCCESS
+        aRewriteRunResult.outcome == TaskOutcome.SUCCESS
+        bRewriteRunResult.outcome == TaskOutcome.SUCCESS
         aTestClass.text == aTestClassExpected
         bTestClass.text == bTestClassExpected
 
@@ -249,7 +270,7 @@ class RewritePluginTest extends RewriteTestBase {
     }
 
     @Ignore("Not yet updated for rewrite 7.0.0")
-    def "rewriteFix applies recipes provided from external dependencies on multi-project builds"() {
+    def "rewriteRun applies recipes provided from external dependencies on multi-project builds"() {
         given:
         File settings = projectDir.newFile("settings.gradle")
         settings.text = """\
@@ -307,9 +328,9 @@ class RewritePluginTest extends RewriteTestBase {
                 }
             """.stripIndent()
         when:
-        def result = gradleRunner(gradleVersion, "rewriteFix").build()
-        def aRewriteFixResult = result.task(":a:rewriteFixTest")
-        def bRewriteFixResult = result.task(":b:rewriteFixTest")
+        def result = gradleRunner(gradleVersion, "rewriteRun").build()
+        def aRewriteRunResult = result.task(":a:rewriteRunTest")
+        def bRewriteRunResult = result.task(":b:rewriteRunTest")
         String aTestClassExpected = """\
                 package com.foo;
     
@@ -333,8 +354,8 @@ class RewritePluginTest extends RewriteTestBase {
                 }
         """.stripIndent()
         then:
-        aRewriteFixResult.outcome == TaskOutcome.SUCCESS
-        bRewriteFixResult.outcome == TaskOutcome.SUCCESS
+        aRewriteRunResult.outcome == TaskOutcome.SUCCESS
+        bRewriteRunResult.outcome == TaskOutcome.SUCCESS
         aTestClass.text == aTestClassExpected
         bTestClass.text == bTestClassExpected
 


### PR DESCRIPTION
- Follow-up to https://github.com/openrewrite/rewrite-gradle-plugin/pull/25
- closes #20
- See also: openrewrite/rewrite-maven-plugin#110
- Warrants a major version bump.