### PR TITLE
upstream rewrite core fixes resolve downstream gradle plugin classpath and deserialization issues

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -40,7 +40,9 @@ gradlePlugin {
 
 repositories {
     mavenCentral()
-    mavenLocal()
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+    }
 }
 
 configurations.all {
@@ -66,7 +68,8 @@ val plugin: Configuration by configurations.creating
 configurations.getByName("compileOnly").extendsFrom(plugin)
 
 // Fixed version numbers because com.gradle.plugin-publish will publish poms with requested rather than resolved versions
-val rewriteVersion = "7.1.0"
+// TODO REPLACE BEFORE RELEASE (please :) )
+val rewriteVersion = "7.2.0-SNAPSHOT"
 val prometheusVersion = "1.3.0"
 val nettyVersion = "1.1.0"
 

--- a/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
@@ -111,6 +111,7 @@ public abstract class AbstractRewriteTask extends DefaultTask implements Rewrite
         properties.putAll(gradleProps);
 
         Environment.Builder env = Environment.builder(properties)
+                .scanRuntimeClasspath()
                 .scanClasspath(
                         Stream.concat(
                                 getDependencies().getFiles().stream(),


### PR DESCRIPTION
Consumes upstream changes in rewrite itself, resolves https://github.com/openrewrite/rewrite-gradle-plugin/issues/33
