### PR TITLE
setFailOnInvalidActiveRecipes to configure handling activeRecipe validation errors throwing exceptions

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -35,6 +35,15 @@ public class RewriteExtension extends CodeQualityExtension {
     private String metricsUri = magicalMetricsLogString;
     private String rewriteVersion = "7.2.2";
 
+    /**
+     * Whether to throw an exception if an activeRecipe fails configuration validation.
+     * This may happen if the activeRecipe is improperly configured, or any downstream recipes are improperly configured.
+     * <p>
+     * For the time, this default is "false" to prevent one improperly recipe from failing the build.
+     * In the future, this default may be changed to "true" to be more restrictive.
+     */
+    private boolean failOnInvalidActiveRecipes = false;
+
     @SuppressWarnings("unused")
     public RewriteExtension(Project project) {
         this.project = project;
@@ -121,5 +130,13 @@ public class RewriteExtension extends CodeQualityExtension {
 
     public void setRewriteVersion(String value) {
         rewriteVersion = value;
+    }
+
+    public boolean getFailOnInvalidActiveRecipes() {
+        return failOnInvalidActiveRecipes;
+    }
+
+    public void setFailOnInvalidActiveRecipes(boolean failOnInvalidActiveRecipes) {
+        this.failOnInvalidActiveRecipes = failOnInvalidActiveRecipes;
     }
 }


### PR DESCRIPTION
conceptually part of https://github.com/openrewrite/rewrite-gradle-plugin/issues/45 and builds on the work done in https://github.com/openrewrite/rewrite-gradle-plugin/commit/b2e408eaf268600c16f38a46592457cb77933321

`setFailOnInvalidActiveRecipes(true)` to throw an exception on activeRecipeValidationErrors. By default, it's `false` to maintain status quo. In future major versions if we decide on it, we can make it more restrictive to be `true` by default.

By default:

```
Using active recipe(s) [org.openrewrite.java.testing.junit5.JUnit5BestPractices]
Using active styles(s) []
Validating active recipes...
Recipe validation error in org.openrewrite.java.testing.junit5.JUnit4to5Migration.recipeList[8] (in jar:file:/Users/aegershman/.gradle/caches/modules-2/files-2.1/org.openrewrite.recipe/rewrite-testing-frameworks/1.2.0/13d85fa8d462eefdee782940976237d78bcf6051/rewrite-testing-frameworks-1.2.0.jar!/META-INF/rewrite/junit5.yml): refers to a recipe that doesn't exist.
Recipe validation error in org.openrewrite.java.testing.junit5.JUnit4to5Migration.recipeList[17] (in jar:file:/Users/aegershman/.gradle/caches/modules-2/files-2.1/org.openrewrite.recipe/rewrite-testing-frameworks/1.2.0/13d85fa8d462eefdee782940976237d78bcf6051/rewrite-testing-frameworks-1.2.0.jar!/META-INF/rewrite/junit5.yml): refers to a recipe that doesn't exist.
Recipe validation errors detected as part of one or more activeRecipe(s). Execution will continue regardless.
Parsing Java files...
Parsing YAML files...
Parsing properties files...
Parsing XML files...
Running recipe(s)...
```

with `setFailOnInvalidActiveRecipes(true)`:

```
Using active recipe(s) [org.openrewrite.java.testing.junit5.JUnit5BestPractices]
Using active styles(s) []
Validating active recipes...
Recipe validation error in org.openrewrite.java.testing.junit5.JUnit4to5Migration.recipeList[8] (in jar:file:/Users/aegershman/.gradle/caches/modules-2/files-2.1/org.openrewrite.recipe/rewrite-testing-frameworks/1.2.0/13d85fa8d462eefdee782940976237d78bcf6051/rewrite-testing-frameworks-1.2.0.jar!/META-INF/rewrite/junit5.yml): refers to a recipe that doesn't exist.
Recipe validation error in org.openrewrite.java.testing.junit5.JUnit4to5Migration.recipeList[17] (in jar:file:/Users/aegershman/.gradle/caches/modules-2/files-2.1/org.openrewrite.recipe/rewrite-testing-frameworks/1.2.0/13d85fa8d462eefdee782940976237d78bcf6051/rewrite-testing-frameworks-1.2.0.jar!/META-INF/rewrite/junit5.yml): refers to a recipe that doesn't exist.

> Task :rewriteRunMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rewriteRunMain'.
> org.gradle.api.GradleException: Recipe validation errors detected as part of one or more activeRecipe(s). Please check error logs.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
1 actionable task: 1 executed
```