### PR TITLE
Prevent DryRun from caching .patch files

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -43,6 +44,7 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
         super(configuration, sourceSet, extension);
         setGroup("rewrite");
         setDescription("Dry run the active refactoring recipes to sources within the " + sourceSet.getName() + " SourceSet. No results will be made.");
+        getOutputs().upToDateWhen(Specs.SATISFIES_NONE);
     }
 
     @Override


### PR DESCRIPTION
do not merge, putting here for discussion + thought related to whether it makes sense for subsequent calls to dryRun to output 'up-to-date' even if dryrun technically _would_ make changes.