### PR TITLE
Configurable failOnDryRunResults

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
@@ -41,7 +41,7 @@ public abstract class AbstractRewriteTask extends DefaultTask implements Rewrite
 
     private final Configuration configuration;
     private final SourceSet sourceSet;
-    private final RewriteExtension extension;
+    protected final RewriteExtension extension;
     private final RewriteReflectiveFacade rewrite;
 
     public AbstractRewriteTask(Configuration configuration, SourceSet sourceSet, RewriteExtension extension) {

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -44,7 +45,7 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
         super(configuration, sourceSet, extension);
         setGroup("rewrite");
         setDescription("Dry run the active refactoring recipes to sources within the " + sourceSet.getName() + " SourceSet. No results will be made.");
-        getOutputs().upToDateWhen(task -> !extension.getFailOnDryRunResults());
+        getOutputs().upToDateWhen(Specs.SATISFIES_NONE);
     }
 
     @Override

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -113,7 +113,7 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
             getLog().warn("Run 'mvn rewrite:run' to apply the recipes.");
 
             if (extension.getFailOnDryRunResults()) {
-                throw new GradleException("Result changes detected. Please see result file for more information.");
+                throw new GradleException("Applying recipes would make changes. See logs for more details.");
             }
         }
     }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.gradle;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -43,6 +44,7 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
         super(configuration, sourceSet, extension);
         setGroup("rewrite");
         setDescription("Dry run the active refactoring recipes to sources within the " + sourceSet.getName() + " SourceSet. No results will be made.");
+        getOutputs().upToDateWhen(task -> !extension.getFailOnDryRunResults());
     }
 
     @Override
@@ -108,6 +110,10 @@ public class RewriteDryRunTask extends AbstractRewriteTask {
             getLog().warn("Report available:");
             getLog().warn(indent(1, patchFile.normalize().toString()));
             getLog().warn("Run 'mvn rewrite:run' to apply the recipes.");
+
+            if (extension.getFailOnDryRunResults()) {
+                throw new GradleException("Result changes detected. Please see result file for more information.");
+            }
         }
     }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -44,6 +44,8 @@ public class RewriteExtension extends CodeQualityExtension {
      */
     private boolean failOnInvalidActiveRecipes = false;
 
+    private boolean failOnDryRunResults = false;
+
     @SuppressWarnings("unused")
     public RewriteExtension(Project project) {
         this.project = project;
@@ -139,4 +141,13 @@ public class RewriteExtension extends CodeQualityExtension {
     public void setFailOnInvalidActiveRecipes(boolean failOnInvalidActiveRecipes) {
         this.failOnInvalidActiveRecipes = failOnInvalidActiveRecipes;
     }
+
+    public boolean getFailOnDryRunResults() {
+        return this.failOnDryRunResults;
+    }
+
+    public void setFailOnDryRunResults(boolean failOnDryRunResults) {
+        this.failOnDryRunResults = failOnDryRunResults;
+    }
+
 }


### PR DESCRIPTION
Addresses https://github.com/openrewrite/rewrite-gradle-plugin/issues/42 and https://github.com/openrewrite/rewrite-maven-plugin/issues/139

Configurable flag for determining whether to fail on dry run results. Currently, default is not to fail. This allows a user to configure having dryRun outputting changes result in an exception and thus non-zero exit code.

```kt
rewrite {
    failOnDryRunResults = true
}
```

Example in the case of dryRun producing a result set:

```log
Running recipe(s)...
These recipes would make results to src/main/java/io/slugstack/oss/unspecifiedgradleproject/UnspecifiedGradleProjectApplication.java:
    org.openrewrite.java.format.AutoFormat
Report available:
    /Users/aegershman/projects/slugstack/slugstack-unspecified-gradle-project/build/reports/rewrite/main.patch
Run 'mvn rewrite:run' to apply the recipes.

> Task :rewriteDryRunMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rewriteDryRunMain'.
> Result changes detected. Please see result file for more information.
```

or the default (as in, `false`), which is the status quo:

```log
Running recipe(s)...
These recipes would make results to src/test/java/io/slugstack/oss/unspecifiedgradleproject/UnspecifiedGradleProjectApplicationTests.java:
    org.openrewrite.java.format.AutoFormat
Report available:
    /Users/aegershman/projects/slugstack/slugstack-unspecified-gradle-project/build/reports/rewrite/test.patch
Run 'mvn rewrite:run' to apply the recipes.

BUILD SUCCESSFUL in 8s
4 actionable tasks: 2 executed, 2 up-to-date
```