### PR TITLE
Option for binding rewriteDryRun to 'check' tasks

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -46,6 +46,14 @@ public class RewriteExtension extends CodeQualityExtension {
 
     private boolean failOnDryRunResults = false;
 
+    /**
+     * Whether "rewriteDryRun" should run as part of Gradle's "check" task.
+     * <p>
+     * For the time, this default is "false" to be backwards-compatible and prevent "rewriteDryRun" from being too intrusive.
+     * In the future, this default may be changed to "true".
+     */
+    private boolean doDryRunOnCheck = false;
+
     @SuppressWarnings("unused")
     public RewriteExtension(Project project) {
         this.project = project;
@@ -150,4 +158,11 @@ public class RewriteExtension extends CodeQualityExtension {
         this.failOnDryRunResults = failOnDryRunResults;
     }
 
+    public boolean getDoDryRunOnCheck() {
+        return this.doDryRunOnCheck;
+    }
+
+    public void setDoDryRunOnCheck(boolean doDryRunOnCheck) {
+        this.doDryRunOnCheck = doDryRunOnCheck;
+    }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -76,6 +75,13 @@ public class RewritePlugin implements Plugin<Project> {
                     task.setDescription("Dry run the active refactoring recipes to all sources. No changes will be made.");
                 })
         );
+        project.afterEvaluate(unused -> {
+            if (extension.getDoDryRunOnCheck()) {
+                // rewriteDryRun hooks into the regular Java build by becoming a dependency of "check" the same way linters and unit tests do
+                Task checkTask = tasks.getByName(JavaBasePlugin.CHECK_TASK_NAME);
+                checkTask.dependsOn(rewriteDryRunAll);
+            }
+        });
 
         Task rewriteDiscoverAll = tasks.create("rewriteDiscover", taskClosure(task -> {
             task.setGroup("rewrite");


### PR DESCRIPTION
See: https://github.com/openrewrite/rewrite-gradle-plugin/issues/43
See: https://github.com/openrewrite/rewrite-gradle-plugin/pull/21

Enables having `rewriteDryRun` be bound to the `check` task or not.

```groovy
rewrite {
  doDryRunOnCheck = {true,false}
}
```

Default is `false` for backwards-compatibility and to not have `rewriteDryRun` cause more noise than necessary at the moment. The default could be made `true` in the future. It depends on what the best user experience is. In any case, having this as a configurable option means users can straightforwardly link or unlink `rewriteDryRun` from `check`, regardless of how we set the default.

---

Example when `doDryRunOnCheck = true`:

```sh
./gradlew check
```

```log
./gradlew check
> Task :rewriteDryRunMain
Using active recipe(s) [org.openrewrite.java.format.AutoFormat, org.openrewrite.java.testing.junit5.JUnit5BestPractices]
Using active styles(s) []
Validating active recipes...
Parsing Java files...
Parsing YAML files...
Parsing properties files...
Parsing XML files...
Running recipe(s)...
These recipes would make results to src/main/java/io/slugstack/oss/unspecifiedgradleproject/UnspecifiedGradleProjectApplication.java:
    org.openrewrite.java.format.AutoFormat
Report available:
    /Users/aegershman/projects/slugstack/slugstack-unspecified-gradle-project/build/reports/rewrite/main.patch
Run 'mvn rewrite:run' to apply the recipes.

> Task :rewriteDryRunTest
Using active recipe(s) [org.openrewrite.java.format.AutoFormat, org.openrewrite.java.testing.junit5.JUnit5BestPractices]
Using active styles(s) []
Validating active recipes...
Parsing Java files...
Parsing YAML files...
Parsing properties files...
Parsing XML files...
Running recipe(s)...

BUILD SUCCESSFUL
6 actionable tasks: 2 executed, 4 up-to-date
```