### PR TITLE
unlink rewriteRun and compile tasks to allow partially-complete transformations to execute

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -93,10 +93,6 @@ public class RewritePlugin implements Plugin<Project> {
             RewriteDiscoverTask discoverTask = tasks.create(rewriteDiscoverTaskName, RewriteDiscoverTask.class, rewriteConf, sourceSet, extension);
             rewriteDiscoverAll.dependsOn(discoverTask);
 
-            String compileTaskName = sourceSet.getCompileTaskName("java");
-            Task compileTask = tasks.getByName(compileTaskName);
-            compileTask.configure(taskClosure(it -> it.mustRunAfter(rewriteRun)));
-
             String rewriteDryRunTaskName = "rewriteDryRun" + sourceSet.getName().substring(0, 1).toUpperCase() + sourceSet.getName().substring(1);
             RewriteDryRunTask rewriteDryRun = tasks.create(rewriteDryRunTaskName, RewriteDryRunTask.class, rewriteConf, sourceSet, extension);
             rewriteDryRunAll.configure(taskClosure(it -> it.dependsOn(rewriteDryRun)));


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-gradle-plugin/issues/32

In order to enable users to execute recipes which solves _most_ problems (but technically leaves the source code in a non-compilable state), remove the link between `rewriteRun` and `compile`. The link appears to exist for validation purposes, but is not strictly necessary.

This is valuable in situations where a recipe gets 90% of work done, but still requires a smidgeon of manual intervention.