### PR TITLE
Clear JavaType flyweights on task completion

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteReflectiveFacade.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteReflectiveFacade.java
@@ -937,4 +937,14 @@ public class RewriteReflectiveFacade {
             throw new RuntimeException(e);
         }
     }
+
+    public void clearFlyweights() {
+        try {
+            Class<?> c = getClassLoader().loadClass("org.openrewrite.java.tree.JavaType");
+            Method javaTypeClearCaches = c.getMethod("clearCaches");
+            javaTypeClearCaches.invoke(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
Gradle's daemon process persists across builds and running rewrite's tasks multiple times was resulting in out-of-memory issues. This fix clears the flyweight cache in JavaTypes which greatly reduces memory pressure in the daemon.
