### PR TITLE
build: gradle wrapper 7.3.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -51,15 +51,6 @@ configurations.all {
     resolutionStrategy {
         cacheChangingModulesFor(0, TimeUnit.SECONDS)
         cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
-        if(isTestConfiguration) {
-            eachDependency {
-                if (requested.group == "org.codehaus.groovy" && requested.version == "3.0.9") {
-                    useVersion("3.0.8")
-                    because("spock-bom:2.0-groovy-3.0 requires 3.0.8, rewrite-groovy pulls in 3.0.9. " +
-                        "Using groovy to run this project's tests is a headache and we should migrate them to Java.")
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
build: gradle wrapper 7.3.3

Remove the pinning of groovy 3.0.8, because in gradle 7.3.3, groovy 3.0.9 is used: https://docs.gradle.org/current/userguide/upgrading_version_7.html#changes_7.3

When there's mismatching versions of groovy, these kinds of errors crop up in the spock tests:

```
RewriteDiscoverTest > initializationError FAILED
    org.spockframework.util.InternalSpockError at PlatformSpecRunner.java:80
        Caused by: java.lang.ExceptionInInitializerError at InvokerHelper.java:88
            Caused by: groovy.lang.GroovyRuntimeException at MetaClassRegistryImpl.java:510

RewriteDryRunTest > initializationError FAILED
    org.spockframework.util.InternalSpockError at PlatformSpecRunner.java:80
        Caused by: java.lang.NoClassDefFoundError at NativeConstructorAccessorImpl.java:-2

RewriteMetricsPluginTests > initializationError FAILED
    org.spockframework.util.InternalSpockError at PlatformSpecRunner.java:80
        Caused by: java.lang.NoClassDefFoundError at NativeConstructorAccessorImpl.java:-2

RewriteRunTest > initializationError FAILED
    org.spockframework.util.InternalSpockError at PlatformSpecRunner.java:80
        Caused by: java.lang.NoClassDefFoundError at NativeConstructorAccessorImpl.java:-2

4 tests completed, 4 failed
```

Getting rid of this entire section below works out just fine, since the testimplementation dependency on gradle itself now is being fed groovy 3.0.9.