### PR TITLE
Plain text masks

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
@@ -302,7 +302,7 @@ public class DefaultRewriteExtension implements RewriteExtension {
     public List<String> getPlainTextMasks() {
         if (plainTextMasks.isEmpty()) {
             plainTextMasks.addAll(Arrays.asList(
-                    "gradlew",
+                    "**/gradlew",
                     "**/META-INF/services/**",
                     "**/.gitignore",
                     "**/.gitattributes",

--- a/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
@@ -22,10 +22,7 @@ import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.PathMatcher;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -44,6 +41,8 @@ public class DefaultRewriteExtension implements RewriteExtension {
     private String metricsUri = magicalMetricsLogString;
     private boolean enableExperimentalGradleBuildScriptParsing = true;
     private final List<String> exclusions = new ArrayList<>();
+    private final List<String> plainTextMasks = new ArrayList<>();
+
     private int sizeThresholdMb = 10;
 
     @Nullable
@@ -297,6 +296,37 @@ public class DefaultRewriteExtension implements RewriteExtension {
     @Override
     public void exclusion(Collection<String> exclusions) {
         this.exclusions.addAll(exclusions);
+    }
+
+    @Override
+    public List<String> getPlainTextMasks() {
+        if (plainTextMasks.isEmpty()) {
+            plainTextMasks.addAll(Arrays.asList(
+                    "gradlew",
+                    "**/META-INF/services/**",
+                    "**/.gitignore",
+                    "**/.gitattributes",
+                    "**/.java-version",
+                    "**/.sdkmanrc",
+                    "**/*.sh",
+                    "**/*.bash",
+                    "**/*.bat",
+                    "**/*.ksh",
+                    "**/*.txt",
+                    "**/*.jsp"
+            ));
+        }
+        return plainTextMasks;
+    }
+
+    @Override
+    public void plainTextMask(String... masks) {
+        this.plainTextMasks.addAll(asList(masks));
+    }
+
+    @Override
+    public void plainTextMask(Collection<String> masks) {
+        this.plainTextMasks.addAll(masks);
     }
 
     @Override

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("unused")
 public interface RewriteExtension {
     void setConfigFile(File configFile);
 
@@ -97,6 +98,12 @@ public interface RewriteExtension {
     void exclusion(String... exclusions);
 
     void exclusion(Collection<String> exclusions);
+
+    List<String> getPlainTextMasks();
+
+    void plainTextMask(String... masks);
+
+    void plainTextMask(Collection<String> masks);
 
     int getSizeThresholdMb();
 

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
@@ -251,8 +251,12 @@ public class ResourceParser {
 
     private boolean isParsedAsPlainText(Path path) {
         if (!plainTextMasks.isEmpty()) {
+            Path computed = baseDir.relativize(path);
+            if (!computed.startsWith("/")) {
+                computed = Paths.get("/").resolve(computed);
+            }
             for (PathMatcher matcher : plainTextMasks) {
-                if (matcher.matches(baseDir.relativize(path))) {
+                if (matcher.matches(computed)) {
                     return true;
                 }
             }

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
@@ -48,11 +48,15 @@ public class ResourceParser {
     private static final Logger logger = Logging.getLogger(ResourceParser.class);
     private final Path baseDir;
     private final Collection<PathMatcher> exclusions;
+
+    private final Collection<PathMatcher> plainTextMasks;
+
     private final int sizeThresholdMb;
 
     public ResourceParser(Path baseDir, Project project, RewriteExtension extension) {
         this.baseDir = baseDir;
-        this.exclusions = exclusionMatchers(baseDir, mergeExclusions(project, extension));
+        this.exclusions = pathMatchers(baseDir, mergeExclusions(project, extension));
+        this.plainTextMasks = pathMatchers(baseDir, extension.getPlainTextMasks());
         this.sizeThresholdMb = extension.getSizeThresholdMb();
     }
 
@@ -64,9 +68,9 @@ public class ResourceParser {
         ).collect(toList());
     }
 
-    private Collection<PathMatcher> exclusionMatchers(Path baseDir, Collection<String> exclusions) {
-        return exclusions.stream()
-                .map(o -> baseDir.getFileSystem().getPathMatcher("glob:" + o))
+    private Collection<PathMatcher> pathMatchers(Path basePath, Collection<String> pathExpressions) {
+        return pathExpressions.stream()
+                .map(o -> basePath.getFileSystem().getPathMatcher("glob:" + o))
                 .collect(Collectors.toList());
     }
 
@@ -151,6 +155,7 @@ public class ResourceParser {
                                 "Mb exceeds size threshold " + sizeThresholdMb + "Mb");
                         quarkPaths.add(file);
                     } else if (isParsedAsPlainText(file)) {
+                        System.out.println("Plain Text :" + file);
                         plainTextPaths.add(file);
                     } else {
                         resources.add(file);
@@ -234,24 +239,25 @@ public class ResourceParser {
     }
 
     private boolean isExcluded(Path path) {
-        for (PathMatcher excluded : exclusions) {
-            if (excluded.matches(baseDir.relativize(path))) {
-                return true;
+        if (!exclusions.isEmpty()) {
+            for (PathMatcher excluded : exclusions) {
+                if (excluded.matches(baseDir.relativize(path).toAbsolutePath())) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
     private boolean isParsedAsPlainText(Path path) {
-        String pathString = path.toString();
-
-        return  pathString.contains("/META-INF/services") ||
-                pathString.endsWith(".gitignore")||
-                pathString.endsWith(".gitattributes")||
-                pathString.endsWith(".java-version")||
-                pathString.endsWith(".sdkmanrc") ||
-                pathString.endsWith("gradlew") ||
-                pathString.endsWith("gradlew.bat");
+        if (!plainTextMasks.isEmpty()) {
+            for (PathMatcher matcher : plainTextMasks) {
+                if (matcher.matches(baseDir.relativize(path))) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private boolean isIgnoredDirectory(Path searchDir, Path path) {


### PR DESCRIPTION
Add the ability to configure which files will be parsed as plain text. If no configuration is applied the defaults for the plugin are:

**/META-INF/services/**
**/.gitignore
**/.gitattributes
**/.java-version
**/.sdkmanrc
**/*.sh
**/*.bash
**/*.bat
**/*.ksh
**/*.txt
**/*.jsp

This is related to https://github.com/openrewrite/rewrite/issues/2134