### PR TITLE
Add Java 17 to list of resolved task dependencies

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -63,6 +63,7 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
                     deps.create("org.openrewrite:rewrite-hcl:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-json:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java:" + rewriteVersion),
+                    deps.create("org.openrewrite:rewrite-java-17:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java-11:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java-8:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-maven:" + rewriteVersion),


### PR DESCRIPTION
Add Java 17 to the list of resolved dependencies so that the plugin can find the
Java 17 parser.