### PR TITLE
Filter out files in the build folder.

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -645,7 +645,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                     List<J.CompilationUnit> cus = jp.parse(javaPaths, baseDir, ctx);
                     alreadyParsed.addAll(javaPaths);
                     cus = ListUtils.map(cus, cu -> {
-                        if(isExcluded(exclusions, cu.getSourcePath())) {
+                        if (isExcluded(exclusions, cu.getSourcePath()) || cu.getSourcePath().toString().contains("/build/")) {
                             return null;
                         }
                         return cu;


### PR DESCRIPTION
Filter out `/build/` sources from the list of CUS.