### PR TITLE
Added org.jetbrains.kotlin.multiplatform to accepted plugins in the DefaultProjectParser.

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -682,7 +682,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                     }
                 }
 
-                if(subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.jvm")) {
+                if (subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.jvm") || subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.multiplatform")) {
                     List<Path> kotlinPaths = sourceSet.getAllSource().getFiles().stream()
                             .filter(it -> it.isFile() && it.getName().endsWith(".kt"))
                             .map(File::toPath)


### PR DESCRIPTION
Changes:

- subprojects with `"org.jetbrains.kotlin.multiplatform"` plugin will generate Kotlin source files.

fixes #172