### PR TITLE
Added support to parse kotlin sources from projects with multiproject plugin.

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     compileOnly("org.openrewrite:rewrite-xml")
     compileOnly("org.openrewrite:rewrite-yaml")
     compileOnly("com.puppycrawl.tools:checkstyle:9.3")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:latest.release")
 
     testImplementation(platform("org.junit:junit-bom:latest.release"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -19,8 +19,10 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -28,6 +30,7 @@ import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.service.ServiceRegistry;
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet;
 import org.openrewrite.*;
 import org.openrewrite.binary.Binary;
 import org.openrewrite.config.Environment;
@@ -745,6 +748,11 @@ public class DefaultProjectParser implements GradleProjectParser {
                     }
                 }
 
+                if (subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension")) {
+                    List<SourceFile> cus = parseMultiplatformKotlinProject(subproject, exclusions, alreadyParsed, ctx);
+                    sourceFiles.addAll(cus);
+                }
+
                 if(subproject.getPlugins().hasPlugin(GroovyPlugin.class)) {
                     List<Path> groovyPaths = sourceSet.getAllSource().getFiles().stream()
                             .filter(it -> it.isFile() && it.getName().endsWith(".groovy"))
@@ -823,6 +831,110 @@ public class DefaultProjectParser implements GradleProjectParser {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private List<SourceFile> parseMultiplatformKotlinProject(Project subproject, Collection<PathMatcher> exclusions, Set<Path> alreadyParsed, ExecutionContext ctx) {
+        Object kotlinExtension = subproject.getExtensions().getByName("kotlin");
+        NamedDomainObjectContainer<KotlinSourceSet> sourceSets;
+        try {
+            Class<?> clazz = kotlinExtension.getClass().getClassLoader().loadClass("org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension");
+            //noinspection unchecked
+            sourceSets = (NamedDomainObjectContainer<KotlinSourceSet>) clazz.getMethod("getSourceSets")
+                    .invoke(kotlinExtension);
+
+        } catch (Exception e) {
+            logger.warn("Failed to resolve KotlinMultiplatformExtension from {}. No sources files from KotlinMultiplatformExtension will be parsed.",
+                    subproject.getPath());
+            return emptyList();
+        }
+
+        SortedSet<String> sourceSetNames;
+        try {
+            //noinspection unchecked
+            sourceSetNames = (SortedSet<String>) sourceSets.getClass().getMethod("getNames")
+                    .invoke(sourceSets);
+        } catch (Exception e) {
+            logger.warn("Failed to resolve SourceSetNames in KotlinMultiplatformExtension from {}. No sources files from KotlinMultiplatformExtension will be parsed.",
+                    subproject.getPath());
+            return emptyList();
+        }
+
+        for (String sourceSetName : sourceSetNames) {
+            try {
+                Object sourceSet = sourceSets.getClass().getMethod("getByName", String.class)
+                        .invoke(sourceSets, sourceSetName);
+                SourceDirectorySet kotlinDirectorySet = (SourceDirectorySet) sourceSet.getClass().getMethod("getKotlin").invoke(sourceSet);
+                List<Path> kotlinPaths = kotlinDirectorySet.getFiles().stream()
+                        .filter(it -> it.isFile() && it.getName().endsWith(".kt"))
+                        .map(File::toPath)
+                        .map(Path::toAbsolutePath)
+                        .map(Path::normalize)
+                        .collect(toList());
+
+                // classpath doesn't include the transitive dependencies of the implementation configuration
+                // These aren't needed for compilation, but we want them so recipes have access to comprehensive type information
+                // The implementation configuration isn't resolvable, so we need a new configuration that extends from it
+                String implementationName = (String) sourceSet.getClass().getMethod("getImplementationConfigurationName").invoke(sourceSet);
+                Configuration implementation = subproject.getConfigurations().getByName(implementationName);
+                Configuration rewriteImplementation = subproject.getConfigurations().maybeCreate("rewrite" + implementationName);
+                rewriteImplementation.extendsFrom(implementation);
+
+                Set<File> implementationClasspath;
+                try {
+                    implementationClasspath = rewriteImplementation.resolve();
+                } catch (Exception e) {
+                    logger.warn("Failed to resolve dependencies from {}:{}. Some type information may be incomplete",
+                            subproject.getPath(), implementationName);
+                    implementationClasspath = emptySet();
+                }
+
+                String compileName = (String) sourceSet.getClass().getMethod("getCompileOnlyConfigurationName").invoke(sourceSet);
+                Configuration compileOnly = subproject.getConfigurations().getByName(compileName);
+                Configuration rewriteCompileOnly = subproject.getConfigurations().maybeCreate("rewrite" + compileName);
+                rewriteCompileOnly.setCanBeResolved(true);
+                rewriteCompileOnly.extendsFrom(compileOnly);
+
+                // The implementation configuration doesn't include build/source directories from project dependencies
+                // So mash it and our rewriteImplementation together to get everything
+                List<Path> dependencyPaths = Stream.concat(implementationClasspath.stream(), rewriteCompileOnly.getFiles().stream())
+                        .map(File::toPath)
+                        .map(Path::toAbsolutePath)
+                        .map(Path::normalize)
+                        .distinct()
+                        .collect(toList());
+
+                if (!kotlinPaths.isEmpty()) {
+                    logger.info("Parsing {} Kotlin sources from {}/{}", kotlinPaths.size(), subproject.getName(), kotlinDirectorySet.getName());
+                    KotlinParser kp = KotlinParser.builder()
+                            .classpath(dependencyPaths)
+                            .styles(getStyles())
+                            .typeCache(javaTypeCache)
+                            .logCompilationWarningsAndErrors(extension.getLogCompilationWarningsAndErrors())
+                            .build();
+
+                    Instant start = Instant.now();
+                    List<K.CompilationUnit> cus = kp.parse(kotlinPaths, baseDir, ctx);
+                    alreadyParsed.addAll(kotlinPaths);
+                    cus = ListUtils.map(cus, cu -> {
+                        if (isExcluded(exclusions, cu.getSourcePath())) {
+                            return null;
+                        }
+                        return cu;
+                    });
+                    Duration parseDuration = Duration.between(start, Instant.now());
+                    logger.info("Finished parsing Kotlin sources from {}/{} in {} ({} per source)",
+                            subproject.getName(), kotlinDirectorySet.getName(), prettyPrint(parseDuration), prettyPrint(parseDuration.dividedBy(kotlinPaths.size())));
+                    List<SourceFile> sourceFiles = new ArrayList<>(cus.size());
+                    sourceFiles.addAll(map(autodetectStyle(cus), addProvenance(emptyList(), null)));
+                    return sourceFiles;
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to resolve sourceSet from {}:{}. Some type information may be incomplete",
+                        subproject.getPath(), sourceSetName);
+            }
+        }
+
+        return emptyList();
     }
 
     private boolean isExcluded(Collection<PathMatcher> exclusions, Path path) {

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -731,6 +731,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                                 .typeCache(javaTypeCache)
                                 .logCompilationWarningsAndErrors(extension.getLogCompilationWarningsAndErrors())
                                 .build();
+                        kp.setSourceSet(sourceSet.getName());
 
                         Instant start = Instant.now();
                         List<K.CompilationUnit> cus = kp.parse(kotlinPaths, baseDir, ctx);
@@ -912,6 +913,8 @@ public class DefaultProjectParser implements GradleProjectParser {
                             .typeCache(javaTypeCache)
                             .logCompilationWarningsAndErrors(extension.getLogCompilationWarningsAndErrors())
                             .build();
+
+                    kp.setSourceSet(sourceSetName);
 
                     Instant start = Instant.now();
                     List<K.CompilationUnit> cus = kp.parse(kotlinPaths, baseDir, ctx);

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
@@ -122,4 +122,76 @@ class RewriteDryRunTest : RewritePluginTest {
         assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
         assertThat(File(projectDir, "build/reports/rewrite/rewrite.patch").exists()).isTrue
     }
+
+    @Test
+    fun testMultiplatform(@TempDir projectDir: File) {
+        gradleProject(projectDir) {
+            buildGradle("""
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                    id("org.jetbrains.kotlin.multiplatform") version "1.8.0"
+                }
+                group = "org.example"
+                version = "1.0-SNAPSHOT"
+                
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                       url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                    }
+                }
+
+                kotlin {
+                    jvm {
+                        jvmToolchain(8)
+                        withJava()
+                    }
+
+                    sourceSets {
+                        commonMain {
+                            dependencies {
+                            }
+                        }
+                        commonTest {
+                            dependencies {
+                            }
+                        }
+                        jvmMain {
+                        }
+                        jvmTest {
+                        }
+                    }
+                }
+            """)
+            settingsGradle("""
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        maven { url = uri("https://plugins.gradle.org/m2") }
+                        gradlePluginPortal()
+                    }
+                }
+                rootProject.name = "example"
+            """)
+            sourceSet("commonMain") {
+                kotlin("""
+                    class HelloWorld {
+                        fun sayHello() {
+                            println("Hello world")
+                        }
+                    }
+                """)
+            }
+        }
+        val gradleVersion = System.getProperty("org.openrewrite.test.gradleVersion")
+        if (gradleVersion >= "6.1") {
+            val result = runGradle(projectDir, "rewriteDryRun", "-DactiveRecipe=org.openrewrite.kotlin.FindKotlinSources")
+            val rewriteDryRunResult = result.task(":rewriteDryRun")!!
+
+            assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(File(projectDir, "build/reports/rewrite/rewrite.patch").exists()).isTrue
+        }
+    }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
@@ -18,6 +18,7 @@ package org.openrewrite.gradle
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
@@ -123,6 +124,7 @@ class RewriteDryRunTest : RewritePluginTest {
         assertThat(File(projectDir, "build/reports/rewrite/rewrite.patch").exists()).isTrue
     }
 
+    @DisabledIf("lessThanGradle6_1")
     @Test
     fun testMultiplatform(@TempDir projectDir: File) {
         gradleProject(projectDir) {
@@ -185,13 +187,10 @@ class RewriteDryRunTest : RewritePluginTest {
                 """)
             }
         }
-        val gradleVersion = System.getProperty("org.openrewrite.test.gradleVersion")
-        if (gradleVersion >= "6.1") {
-            val result = runGradle(projectDir, "rewriteDryRun", "-DactiveRecipe=org.openrewrite.kotlin.FindKotlinSources")
-            val rewriteDryRunResult = result.task(":rewriteDryRun")!!
+        val result = runGradle(projectDir, "rewriteDryRun", "-DactiveRecipe=org.openrewrite.kotlin.FindKotlinSources")
+        val rewriteDryRunResult = result.task(":rewriteDryRun")!!
 
-            assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
-            assertThat(File(projectDir, "build/reports/rewrite/rewrite.patch").exists()).isTrue
-        }
+        assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(File(projectDir, "build/reports/rewrite/rewrite.patch").exists()).isTrue
     }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
@@ -17,6 +17,7 @@ package org.openrewrite.gradle
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import java.io.File
 import java.lang.management.ManagementFactory
 
@@ -38,4 +39,9 @@ interface RewritePluginTest {
             .forwardOutput()
             .build()
 
+
+    fun lessThanGradle6_1(): Boolean {
+        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
+        return currentVersion < GradleVersion.version("6.1")
+    }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -21,7 +21,6 @@ package org.openrewrite.gradle
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.condition.DisabledOnOs
@@ -773,7 +772,7 @@ class RewriteRunTest : RewritePluginTest {
         val rewriteRunResult = result.task(":rewriteRun")!!
         assertThat(rewriteRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-        val fooDir = projectDir.resolve("foo");
+        val fooDir = projectDir.resolve("foo")
         val fooProperties = fooDir.resolve("foo.properties")
         assertThat(!fooProperties.exists())
             .`as`("Recipe should have deleted foo/foo.properties, but it still exists")
@@ -933,10 +932,4 @@ class RewriteRunTest : RewritePluginTest {
             .`as`("Applicability test should have prevented this file from being altered")
             .isEqualTo("jonathan")
     }
-
-    fun lessThanGradle6_1(): Boolean {
-        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
-        return currentVersion < GradleVersion.version("6.1")
-    }
 }
-


### PR DESCRIPTION
Changes:
- Kotlin source will be detected and parsed from projects that use the `org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension` plugin.
    - Before the changes Kotlin source would only be parsed when the `org.jetbrains.kotlin.jvm` plugin exists in the project.

fixes #181 