### PR TITLE
Make checkstyle an optional dependency

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -75,11 +75,18 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
                     deps.create("org.openrewrite:rewrite-yaml:" + rewriteVersion),
                     deps.create("org.openrewrite.gradle.tooling:model:" + extension.getRewriteGradleModelVersion()),
 
-                    // This is an optional dependency of rewrite-java needed when projects also apply the checkstyle plugin
-                    deps.create("com.puppycrawl.tools:checkstyle:" + extension.getCheckstyleToolsVersion()),
                     deps.create("com.fasterxml.jackson.module:jackson-module-kotlin:" + extension.getJacksonModuleKotlinVersion()),
                     deps.create("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:" + extension.getJacksonModuleKotlinVersion())
             };
+
+            // This is an optional dependency of rewrite-java needed when projects also apply the checkstyle plugin
+            String checkstyleVersion = extension.getCheckstyleToolsVersion();
+            if (checkstyleVersion != null) {
+                dependencies = Stream.concat(
+                        Arrays.stream(dependencies),
+                        Stream.of(deps.create("com.puppycrawl.tools:checkstyle:" + checkstyleVersion))
+                ).toArray(Dependency[]::new);
+            }
             if (configuration != null) {
                 dependencies = Stream.concat(
                         Arrays.stream(dependencies),


### PR DESCRIPTION
Currently the Gradple plugin forces to include checkstyle. This PR only adds it in the `Dependencies[]` to resolve when the version is not `null`.

Without it running the `rewriteRun` task results in:

```console
Execution failed for task ':rewriteResolveDependencies'.
> Could not resolve all dependencies for configuration ':detachedConfiguration5'.
  The project declares repositories, effectively ignoring the repositories you have declared in the settings.
  You can figure out how project repositories are declared by configuring your build to fail on project repositories.
  See https://docs.gradle.org/8.0.2/userguide/declaring_repositories.html#sub:fail_build_on_project_repositories for details.
   > Could not find com.puppycrawl.tools:checkstyle:null.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/puppycrawl/tools/checkstyle/null/checkstyle-null.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :

```