### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ plugins {
 
 ## Documentation
 
-- [OpenRewrite Quickstart Guide](https://docs.openrewrite.org/getting-started/getting-started)
+- [OpenRewrite Quickstart Guide](https://docs.openrewrite.org/running-recipes/getting-started)
 - [Gradle Plugin Reference](https://docs.openrewrite.org/reference/gradle-plugin-configuration)


### PR DESCRIPTION
The lower part of README.md shows:

![image](https://user-images.githubusercontent.com/1366654/235372626-349b7a37-ba72-4abe-85ed-15dbbc006860.png)

Both links are 404. This PR fixes the first one.

For the second one, I could not find anything (and therefore opened an isse https://github.com/openrewrite/rewrite-gradle-plugin/issues/196).