### PR TITLE
Correct grammar mistake in dry run reporting output.

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -346,7 +346,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                 }
                 for (Result result : results.refactoredInPlace) {
                     assert result.getBefore() != null;
-                    logger.warn("These recipes would make results to {}:", result.getBefore().getSourcePath());
+                    logger.warn("These recipes would make changes to {}:", result.getBefore().getSourcePath());
                     logRecipesThatMadeChanges(result);
                 }
 


### PR DESCRIPTION
I noticed and corrected a grammatical error in the `rewriteDryRun` task output.