### PR TITLE
Make sure `ResourceParser` returns no `null` sources

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
@@ -321,7 +321,8 @@ public class ResourceParser {
             alreadyParsed.addAll(quarkPaths);
         }
 
-        return sourceFiles;
+        // Filter out `null` values as safeguard against ill-behaved parsers; see https://github.com/openrewrite/rewrite/pull/3322
+        return sourceFiles.filter(Objects::nonNull);
     }
 
     private boolean isOverSizeThreshold(long fileSize) {


### PR DESCRIPTION
A `Parser` is not supposed to return any `null` sources, but we add a safeguard just in case.
