### PR TITLE
Fixes the broken build for RewriteRunTest#deleteEmptyDirectory

### DIFF
--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -752,6 +752,7 @@ class RewriteRunTest : RewritePluginTest {
             propertiesFile("foo/foo.properties", "foo = bar")
             buildGradle("""
                 plugins {
+                    id("groovy")
                     id("org.openrewrite.rewrite")
                 }
                 


### PR DESCRIPTION
## What's changed?

I am adding the groovy plugin to the specific Gradle configuration that is created in the test that is failing. It is the main difference between the failed test and the others that succeed. 
Otherwise, the main branch is broken: https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/5441989672/jobs/9998886947

This seems related to the python project and the latest changes to introduce the new guava dependency
https://github.com/openrewrite/rewrite-python/commits/main. 

```
Could not resolve com.google.guava:guava:32.1.1-jre.

         Required by:

             project : > org.openrewrite:rewrite-python:1.1.0-SNAPSHOT:20230706.182507-37
```

## Anything in particular you'd like reviewers to focus on?

I do not know if this is a required/expected change or not. 

## Anyone you would like to review specifically?

@knutwannheden 
@timtebeek 

## Have you considered any alternatives or workarounds?

Revert the change in python, but the previous one was a version that contains vulnerabilities. 

