### PR TITLE
Fixes the order to process files to avoid quarks

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/ResourceParser.java
@@ -224,11 +224,15 @@ public class ResourceParser {
 
         List<Path> settingsClasspath;
         if (GradleVersion.current().compareTo(GradleVersion.version("4.4")) >= 0) {
-            Settings settings = ((DefaultGradle) project.getGradle()).getSettings();
-            settingsClasspath = settings.getBuildscript().getConfigurations().getByName("classpath").resolve()
-                    .stream()
-                    .map(File::toPath)
-                    .collect(toList());
+            try {
+                Settings settings = ((DefaultGradle) project.getGradle()).getSettings();
+                settingsClasspath = settings.getBuildscript().getConfigurations().getByName("classpath").resolve()
+                        .stream()
+                        .map(File::toPath)
+                        .collect(toList());
+            } catch (IllegalStateException e) {
+                settingsClasspath = emptyList();
+            }
         } else {
             settingsClasspath = emptyList();
         }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -271,7 +271,7 @@ class RewriteRunTest : RewritePluginTest {
                 }
                 
                 rewrite {
-                    activeRecipe("org.openrewrite.java.cleanup.UnnecessaryParentheses")
+                    activeRecipe("org.openrewrite.staticanalysis.UnnecessaryParentheses")
                 }
                 
                 repositories {
@@ -280,6 +280,10 @@ class RewriteRunTest : RewritePluginTest {
                     maven {
                        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
                     }
+                }
+                
+                dependencies {
+                    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.0.4")
                 }
             """)
             sourceSet("main") {


### PR DESCRIPTION
## What's changed?
The order in what the files have been parsed. Before this change, the resources were parsing kotlin files and producing quarks. Also for kotlin projects, resource files were ignored.

It also checks if settings can not be resolved, which helps to properly write a test that validates the parsing. 

## What's your motivation?
Produce correct LSTs

## Anything in particular you'd like reviewers to focus on?
The order in what the files are produced. 

I am working on a test to be added.
