### PR TITLE
fix: use separate rewrite-polyglot version (#233)

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/DefaultRewriteExtension.java
@@ -217,12 +217,13 @@ public class DefaultRewriteExtension implements RewriteExtension {
         return rewriteVersion;
     }
 
+    private String rewritePolyglotVersion;
     @Override
     public String getRewritePolyglotVersion() {
-        if (rewriteVersion == null) {
+        if (rewritePolyglotVersion == null) {
             return getVersionProps().getProperty("org.openrewrite:rewrite-polyglot");
         }
-        return rewriteVersion;
+        return rewritePolyglotVersion;
     }
 
     private String rewriteGradleModelVersion;

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright ${year} the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class RewriteResolveDependenciesTest : RewritePluginTest {
+    @Test
+    fun `Specifying a rewriteVersion does not cause build failures`(
+            @TempDir projectDir: File
+    ) {
+        gradleProject(projectDir) {
+            buildGradle("""
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                }
+                
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                       url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                    }
+                }
+                
+                rewrite {
+                    rewriteVersion = "8.6.1"
+                }
+            """)
+        }
+
+        val result = runGradle(projectDir, "rewriteResolveDependencies")
+        val rewriteDryRunResult = result.task(":rewriteResolveDependencies")!!
+        assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+}


### PR DESCRIPTION
This commit fixes issue #233, where specifying a
rewriteVersion inside the rewrite configuration block would result in rewrite-polyglot failing to resolve to a proper version.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The rewrite-polyglot version can be configured independently from the rewrite version.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
See #233.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
