### PR TITLE
exclude parse kotlin files under path `protos/build/generated`

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -738,7 +738,9 @@ public class DefaultProjectParser implements GradleProjectParser {
                 }
 
                 if (subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.jvm")) {
+                    String excludedProtosPath = subproject.getProjectDir().getPath() + "/protos/build/generated";
                     List<Path> kotlinPaths = unparsedSources.stream()
+                            .filter(it -> !it.toString().startsWith(excludedProtosPath))
                             .filter(it -> it.toString().endsWith(".kt"))
                             .collect(toList());
 


### PR DESCRIPTION
Fixes https://github.com/moderneinc/customer-requests/issues/48
Exclude parsing generated Kotlin sources from `protos/build/generated`