### PR TITLE
Update gradle enterprise setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![ci](https://github.com/openrewrite/rewrite-gradle-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/openrewrite/rewrite-gradle-plugin/actions/workflows/ci.yml)
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org.openrewrite/plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/org.openrewrite.rewrite)
 [![Apache 2.0](https://img.shields.io/github/license/openrewrite/rewrite-gradle-plugin.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.openrewrite.org/scans)
 [![Contributing Guide](https://img.shields.io/badge/Contributing-Guide-informational)](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md)
 
 ## What is this?

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,8 +4,8 @@ include("plugin")
 include("metrics")
 
 plugins {
-    id("com.gradle.enterprise") version "3.12.3"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.2"
+    id("com.gradle.enterprise") version "3.16"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.12.1"
 }
 
 gradleEnterprise {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,9 @@ gradleEnterprise {
     buildCache {
         remote(HttpBuildCache::class) {
             url = uri("https://ge.openrewrite.org/cache/")
-            isPush = isCiServer
+            // Check access key presence to avoid build cache errors on PR builds when access key is not present
+            val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+            isPush = isCiServer && !accessKey.isNullOrEmpty()
         }
     }
 


### PR DESCRIPTION
## What's changed?

- Added Revved up by Develocity badge
- Bumped Gradle Enterprise and Common Custom User Data plugins to latest versions
- Updated remote build cache config to only push when authenticated


## What's your motivation?
- Bumped Gradle Enterprise and Common Custom User Data plugins to latest versions -> improved scans and support for gradle enterprise (server) 2023.4
- Updated remote build cache config to only push when authenticated -> if an unauthenticated push is attempted remote build cache will get turned off for the rest of the build. This can happen (does) on forked PR builds which run in an unsecure environment. 


## Anything in particular you'd like reviewers to focus on?

In general, we strongly suggest to apply these fixes/updates to the rest of your projects, especially if you have a nice rewrite rule to do it for you 😄 

