### PR TITLE
Add rewrite-java-21 to resolved dependencies

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -66,6 +66,7 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
                     deps.create("org.openrewrite:rewrite-json:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-kotlin:" + extension.getRewriteKotlinVersion()),
                     deps.create("org.openrewrite:rewrite-java:" + rewriteVersion),
+                    deps.create("org.openrewrite:rewrite-java-21:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java-17:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java-11:" + rewriteVersion),
                     deps.create("org.openrewrite:rewrite-java-8:" + rewriteVersion),


### PR DESCRIPTION
Noticed while exploring another issue related to a project without repositories on the main project, which lead to
> org.gradle.internal.resolve.ModuleVersionNotFoundException: Cannot resolve external dependency org.openrewrite:rewrite-core:8.11.5 because no repositories are defined