### PR TITLE
Fix resources exclusion in a multi-module project with git repo

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -270,7 +270,7 @@ public class DefaultProjectParser implements GradleProjectParser {
 
     public Collection<Path> listSources() {
         // Use a sorted collection so that gradle input detection isn't thrown off by ordering
-        Set<Path> result = new TreeSet<>(omniParser(emptySet()).acceptedPaths(baseDir, project.getProjectDir().toPath()));
+        Set<Path> result = new TreeSet<>(omniParser(emptySet(), project).acceptedPaths(baseDir, project.getProjectDir().toPath()));
         //noinspection deprecation
         JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
         if (javaConvention != null) {
@@ -809,7 +809,7 @@ public class DefaultProjectParser implements GradleProjectParser {
 
                 for (File resourcesDir : sourceSet.getResources().getSourceDirectories()) {
                     if (resourcesDir.exists() && !alreadyParsed.contains(resourcesDir.toPath())) {
-                        OmniParser omniParser = omniParser(alreadyParsed);
+                        OmniParser omniParser = omniParser(alreadyParsed, subproject);
                         List<Path> accepted = omniParser.acceptedPaths(baseDir, resourcesDir.toPath());
                         sourceSetSourceFiles = Stream.concat(
                                 sourceSetSourceFiles,
@@ -958,7 +958,7 @@ public class DefaultProjectParser implements GradleProjectParser {
         Stream<SourceFile> sourceFiles = Stream.empty();
         int fileCount = 0;
         if (project == project.getRootProject()) {
-            OmniParser omniParser = omniParser(alreadyParsed);
+            OmniParser omniParser = omniParser(alreadyParsed, project);
             List<Path> gradleWrapperFiles = Stream.of(
                             "gradlew", "gradlew.bat",
                             "gradle/wrapper/gradle-wrapper.jar",
@@ -978,13 +978,13 @@ public class DefaultProjectParser implements GradleProjectParser {
 
     protected SourceFileStream parseNonProjectResources(Project subproject, Set<Path> alreadyParsed, ExecutionContext ctx, List<Marker> projectProvenance, Stream<SourceFile> sourceFiles) {
         //Collect any additional yaml/properties/xml files that are NOT already in a source set.
-        OmniParser omniParser = omniParser(alreadyParsed);
+        OmniParser omniParser = omniParser(alreadyParsed, subproject);
         List<Path> accepted = omniParser.acceptedPaths(baseDir, subproject.getProjectDir().toPath());
         return SourceFileStream.build("", s -> {
         }).concat(omniParser.parse(accepted, baseDir, ctx), accepted.size());
     }
 
-    private OmniParser omniParser(Set<Path> alreadyParsed) {
+    private OmniParser omniParser(Set<Path> alreadyParsed, Project project) {
         return OmniParser.builder(
                         OmniParser.defaultResourceParsers(),
                         PlainTextParser.builder()

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
@@ -241,3 +241,15 @@ class GradleSourceSetSpec(
 fun gradleProject(dir: File, init: GradleProjectSpec.()->Unit): GradleProjectSpec {
     return GradleProjectSpec(dir).apply(init).build()
 }
+
+fun commitFilesToGitRepo(dir: File) {
+    exec("git init", dir)
+    exec("git config user.email user@test.com", dir)
+    exec("git config user.name TestUser", dir)
+    exec("git add .", dir)
+    exec("git commit -m \"Initial commit\"", dir)
+}
+
+private fun exec(command: String, workingDirectory: File) {
+    Runtime.getRuntime().exec(command, null, workingDirectory)
+}


### PR DESCRIPTION
## What's changed?
Fixed the bug with resources in subproject being excluded from processing.

## What's your motivation?
I have a multi-module project like this:
```
.
├── src
│   └── main
│       └── resources
│           └── application-root.yml
└── subproject
    └── src
        └── main
            └── resources
                └── application-subproject.yml  
```
And I have a custom recipe to modify some YAML. While the `application-root.yml` is correctly modified, the `application-subproject.yml` is skipped. It is reproduced in the `resources in subproject committed to git are correctly processed` test case.

There is already a test case `rewriteRun applies recipe to a multi-project build` which aims to verify this situation, but it doesn't check the case when Git repo is available. There is a different code path in `OmniParser` for such case and it's not reached.

I believe that I've found a bug in the code of `DefaultProjectParser`. When the `OmniParser` is created for the root project, it is configured to exclude contents of its subprojects. But when it's created for the subproject, it's still configured to exclude the root project's subprojects, so also the subproject we want to parse.

## Anything in particular you'd like reviewers to focus on?
I've added the `Project` parameter to the `omniParser()`. Please verify that the updated method usages are correct.

## Additional changes
There was a typo in `dependencyRepositoriesDeclaredInSettings` test case which caused the test to fail. I fixed it: `nevVersion` -> `newVersion`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
