### PR TITLE
Resolve rewrite dependencies from `-Pmoderne.gradle.classpath` if provided

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -60,13 +60,8 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
             if (project.getRepositories().isEmpty()) {
                 project.getRepositories().mavenCentral();
                 if (rewriteVersion.endsWith("-SNAPSHOT")) {
-                    project.getRepositories().maven(mavenArtifactRepository -> {
-                        mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/");
-                        mavenArtifactRepository.mavenContent(mavenContent -> {
-                            mavenContent.includeGroup("org.openrewrite");
-                            mavenContent.includeGroup("org.openrewrite.gradle.tooling");
-                        });
-                    });
+                    project.getRepositories().maven(mavenArtifactRepository ->
+                            mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
                 }
             }
             DependencyHandler deps = project.getDependencies();

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -64,8 +64,9 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
             String rewriteVersion = extension.getRewriteVersion();
             Project project = getProject();
             DependencyHandler deps = project.getDependencies();
-            if (System.getProperty("moderne.gradle.classpath") != null) {
-                try(Stream<Path> paths = Files.walk(Paths.get(System.getProperty("moderne.classpath")))) {
+            String classpathProp = System.getProperty("moderne.gradle.classpath");
+            if (classpathProp != null) {
+                try(Stream<Path> paths = Files.walk(Paths.get(classpathProp))) {
                     resolvedDependencies = paths
                             .map(Path::toFile)
                             .collect(Collectors.toSet());

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -57,13 +57,6 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
         if (resolvedDependencies == null) {
             String rewriteVersion = extension.getRewriteVersion();
             Project project = getProject();
-            if (project.getRepositories().isEmpty()) {
-                project.getRepositories().mavenCentral();
-                if (rewriteVersion.endsWith("-SNAPSHOT")) {
-                    project.getRepositories().maven(mavenArtifactRepository ->
-                            mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
-                }
-            }
             DependencyHandler deps = project.getDependencies();
             Dependency[] dependencies = new Dependency[]{
                     deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -36,10 +36,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toSet;
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
 import static org.gradle.api.attributes.java.TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE;
 
@@ -61,72 +62,79 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
     @Internal
     public Set<File> getResolvedDependencies() {
         if (resolvedDependencies == null) {
-            String rewriteVersion = extension.getRewriteVersion();
-            Project project = getProject();
-            DependencyHandler deps = project.getDependencies();
-            String classpathProp = System.getProperty("moderne.gradle.classpath");
-            if (classpathProp != null) {
-                try (Stream<Path> paths = Files.walk(Paths.get(classpathProp))) {
-                    resolvedDependencies = paths
-                            .map(Path::toFile)
-                            .collect(Collectors.toSet());
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            } else {
-                Dependency[] dependencies = new Dependency[]{
-                        deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-groovy:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-gradle:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-hcl:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-json:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-kotlin:" + extension.getRewriteKotlinVersion()),
-                        deps.create("org.openrewrite:rewrite-java:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-java-21:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-java-17:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-java-11:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-java-8:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-maven:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-properties:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-protobuf:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-xml:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-yaml:" + rewriteVersion),
-                        deps.create("org.openrewrite:rewrite-polyglot:" + extension.getRewritePolyglotVersion()),
-                        deps.create("org.openrewrite.gradle.tooling:model:" + extension.getRewriteGradleModelVersion()),
-
-                        // This is an optional dependency of rewrite-java needed when projects also apply the checkstyle plugin
-                        deps.create("com.puppycrawl.tools:checkstyle:" + extension.getCheckstyleToolsVersion()),
-                        deps.create("com.fasterxml.jackson.module:jackson-module-kotlin:" + extension.getJacksonModuleKotlinVersion()),
-                        deps.create("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:" + extension.getJacksonModuleKotlinVersion())
-                };
-                if (configuration != null) {
-                    dependencies = Stream.concat(
-                            Arrays.stream(dependencies),
-                            configuration.getDependencies().stream()
-                    ).toArray(Dependency[]::new);
-                }
-                // By using a detached configuration, we separate this dependency resolution from the rest of the project's
-                // configuration. This also means that Gradle has no criteria with which to select between variants of
-                // dependencies which expose differing capabilities. So those must be manually configured
-                Configuration detachedConf = project.getConfigurations().detachedConfiguration(dependencies);
-
-                try {
-                    ObjectFactory objectFactory = project.getObjects();
-                    detachedConf.attributes(attributes -> {
-                        // Taken from org.gradle.api.plugins.jvm.internal.DefaultJvmEcosystemAttributesDetails
-                        attributes.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
-                        attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-                        attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
-                        attributes.attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
-                        attributes.attribute(TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objectFactory.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM));
-                    });
-                } catch (NoClassDefFoundError e) {
-                    // Old versions of gradle don't have all of these attributes and that's OK
-                }
-                resolvedDependencies = detachedConf.resolve();
-            }
+            resolvedDependencies = Optional.of("moderne.gradle.classpath")
+                    .map(System::getProperty)
+                    .map(this::resolveFromClasspathProperty)
+                    .filter(cp -> !cp.isEmpty())
+                    .orElseGet(this::resolveFromDetachedConfiguration);
         }
         return resolvedDependencies;
+    }
+
+    private Set<File> resolveFromClasspathProperty(String classpathProp) {
+        try (Stream<Path> paths = Files.walk(Paths.get(classpathProp))) {
+            return paths
+                    .map(Path::toFile)
+                    .collect(toSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Set<File> resolveFromDetachedConfiguration() {
+        String rewriteVersion = extension.getRewriteVersion();
+        Project project = getProject();
+        DependencyHandler deps = project.getDependencies();
+        Dependency[] dependencies = new Dependency[]{
+                deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-groovy:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-gradle:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-hcl:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-json:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-kotlin:" + extension.getRewriteKotlinVersion()),
+                deps.create("org.openrewrite:rewrite-java:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-java-21:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-java-17:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-java-11:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-java-8:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-maven:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-properties:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-protobuf:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-xml:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-yaml:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-polyglot:" + extension.getRewritePolyglotVersion()),
+                deps.create("org.openrewrite.gradle.tooling:model:" + extension.getRewriteGradleModelVersion()),
+
+                // This is an optional dependency of rewrite-java needed when projects also apply the checkstyle plugin
+                deps.create("com.puppycrawl.tools:checkstyle:" + extension.getCheckstyleToolsVersion()),
+                deps.create("com.fasterxml.jackson.module:jackson-module-kotlin:" + extension.getJacksonModuleKotlinVersion()),
+                deps.create("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:" + extension.getJacksonModuleKotlinVersion())
+        };
+        if (configuration != null) {
+            dependencies = Stream.concat(
+                    Arrays.stream(dependencies),
+                    configuration.getDependencies().stream()
+            ).toArray(Dependency[]::new);
+        }
+        // By using a detached configuration, we separate this dependency resolution from the rest of the project's
+        // configuration. This also means that Gradle has no criteria with which to select between variants of
+        // dependencies which expose differing capabilities. So those must be manually configured
+        Configuration detachedConf = project.getConfigurations().detachedConfiguration(dependencies);
+
+        try {
+            ObjectFactory objectFactory = project.getObjects();
+            detachedConf.attributes(attributes -> {
+                // Taken from org.gradle.api.plugins.jvm.internal.DefaultJvmEcosystemAttributesDetails
+                attributes.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
+                attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+                attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
+                attributes.attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
+                attributes.attribute(TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objectFactory.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM));
+            });
+        } catch (NoClassDefFoundError e) {
+            // Old versions of gradle don't have all of these attributes and that's OK
+        }
+        return detachedConf.resolve();
     }
 
     @TaskAction

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -66,7 +66,7 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
             DependencyHandler deps = project.getDependencies();
             String classpathProp = System.getProperty("moderne.gradle.classpath");
             if (classpathProp != null) {
-                try(Stream<Path> paths = Files.walk(Paths.get(classpathProp))) {
+                try (Stream<Path> paths = Files.walk(Paths.get(classpathProp))) {
                     resolvedDependencies = paths
                             .map(Path::toFile)
                             .collect(Collectors.toSet());

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -57,6 +57,9 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
         if (resolvedDependencies == null) {
             String rewriteVersion = extension.getRewriteVersion();
             Project project = getProject();
+            if (project.getRepositories().isEmpty()) {
+                project.getRepositories().mavenLocal();
+            }
             DependencyHandler deps = project.getDependencies();
             Dependency[] dependencies = new Dependency[]{
                     deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),

--- a/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/ResolveRewriteDependenciesTask.java
@@ -57,6 +57,18 @@ public class ResolveRewriteDependenciesTask extends DefaultTask {
         if (resolvedDependencies == null) {
             String rewriteVersion = extension.getRewriteVersion();
             Project project = getProject();
+            if (project.getRepositories().isEmpty()) {
+                project.getRepositories().mavenCentral();
+                if (rewriteVersion.endsWith("-SNAPSHOT")) {
+                    project.getRepositories().maven(mavenArtifactRepository -> {
+                        mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/");
+                        mavenArtifactRepository.mavenContent(mavenContent -> {
+                            mavenContent.includeGroup("org.openrewrite");
+                            mavenContent.includeGroup("org.openrewrite.gradle.tooling");
+                        });
+                    });
+                }
+            }
             DependencyHandler deps = project.getDependencies();
             Dependency[] dependencies = new Dependency[]{
                     deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -19,8 +19,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.dsl.RepositoryHandler;
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.quality.CheckstyleExtension;

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -48,6 +48,14 @@ public class RewritePlugin implements Plugin<Project> {
         }
         RewriteExtension extension = project.getExtensions().create("rewrite", DefaultRewriteExtension.class, project);
 
+        if (project.getRepositories().isEmpty()) {
+            project.getRepositories().mavenCentral();
+            if (extension.getRewriteVersion().endsWith("-SNAPSHOT")) {
+                project.getRepositories().maven(mavenArtifactRepository ->
+                        mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
+            }
+        }
+
         // Rewrite module dependencies put here will be available to all rewrite tasks
         Configuration rewriteConf = project.getConfigurations().maybeCreate("rewrite");
 

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -54,14 +54,7 @@ public class RewritePlugin implements Plugin<Project> {
 
         // At least add mavenLocal() to the repositories, so that the rewrite dependencies can be resolved
         if (isRootProject && project.getRepositories().isEmpty()) {
-            MavenArtifactRepository mavenLocal = project.getRepositories().mavenLocal();
-            // Remove mavenLocal() again if dependency resolution management is present
-            project.getGradle().settingsEvaluated(settings -> {
-                RepositoryHandler repositories = settings.getDependencyResolutionManagement().getRepositories();
-                if (!repositories.isEmpty()) {
-                    project.getRepositories().remove(mavenLocal);
-                }
-            });
+            project.getRepositories().mavenLocal();
         }
 
         // Rewrite module dependencies put here will be available to all rewrite tasks

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -48,12 +48,9 @@ public class RewritePlugin implements Plugin<Project> {
         }
         RewriteExtension extension = project.getExtensions().create("rewrite", DefaultRewriteExtension.class, project);
 
+        // At least add mavenLocal() to the repositories, so that the rewrite dependencies can be resolved
         if (project.getRepositories().isEmpty()) {
-            project.getRepositories().mavenCentral();
-            if (extension.getRewriteVersion().endsWith("-SNAPSHOT")) {
-                project.getRepositories().maven(mavenArtifactRepository ->
-                        mavenArtifactRepository.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
-            }
+            project.getRepositories().mavenLocal();
         }
 
         // Rewrite module dependencies put here will be available to all rewrite tasks

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -52,11 +52,6 @@ public class RewritePlugin implements Plugin<Project> {
         }
         RewriteExtension extension = project.getExtensions().create("rewrite", DefaultRewriteExtension.class, project);
 
-        // At least add mavenLocal() to the repositories, so that the rewrite dependencies can be resolved
-        if (isRootProject && project.getRepositories().isEmpty()) {
-            project.getRepositories().mavenLocal();
-        }
-
         // Rewrite module dependencies put here will be available to all rewrite tasks
         Configuration rewriteConf = project.getConfigurations().maybeCreate("rewrite");
 

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
@@ -45,7 +45,7 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
                 rewrite {
                     rewriteVersion = "8.8.0"
                 }
-            """
+                """
             )
         }
 
@@ -63,7 +63,7 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
                     id("java")
                     id("org.openrewrite.rewrite")
                 }
-            """
+                """
             )
         }
 

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
@@ -24,10 +24,11 @@ import java.io.File
 class RewriteResolveDependenciesTest : RewritePluginTest {
     @Test
     fun `Specifying a rewriteVersion does not cause build failures`(
-            @TempDir projectDir: File
+        @TempDir projectDir: File
     ) {
         gradleProject(projectDir) {
-            buildGradle("""
+            buildGradle(
+                """
                 plugins {
                     id("java")
                     id("org.openrewrite.rewrite")
@@ -44,7 +45,8 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
                 rewrite {
                     rewriteVersion = "8.8.0"
                 }
-            """)
+            """
+            )
         }
 
         val result = runGradle(projectDir, "rewriteResolveDependencies")
@@ -52,4 +54,21 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
         assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 
+    @Test
+    fun `No repositories still resolves`(@TempDir projectDir: File) {
+        gradleProject(projectDir) {
+            buildGradle(
+                """
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                }
+            """
+            )
+        }
+
+        val result = runGradle(projectDir, "rewriteResolveDependencies")
+        val rewriteDryRunResult = result.task(":rewriteResolveDependencies")!!
+        assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
@@ -17,6 +17,7 @@ package org.openrewrite.gradle
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.io.TempDir
@@ -56,7 +57,7 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = ".+")
+    @Disabled("Requires `moderne.gradle.classpath` to be set to a folder contains jars")
     fun `No repositories still resolves`(@TempDir projectDir: File) {
         gradleProject(projectDir) {
             buildGradle(

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteResolveDependenciesTest.kt
@@ -18,6 +18,7 @@ package org.openrewrite.gradle
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
@@ -55,6 +56,7 @@ class RewriteResolveDependenciesTest : RewritePluginTest {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CI", matches = ".+")
     fun `No repositories still resolves`(@TempDir projectDir: File) {
         gradleProject(projectDir) {
             buildGradle(


### PR DESCRIPTION
## What's changed?
If the gradle project has no repositories defined, then resolve released Rewrite dependencies from Maven Central, and snapshots from Sonatype OSS>

## What's your motivation?
Up to now we had been failing with
> ModuleVersionNotFoundException: Cannot resolve external dependency org.openrewrite:rewrite-core:8.11.5 because no repositories are defined.