### PR TITLE
Include compile classpath in dependencies

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -686,11 +686,13 @@ public class DefaultProjectParser implements GradleProjectParser {
                         .filter(it -> it.toString().endsWith(".java") && !alreadyParsed.contains(it))
                         .collect(toList());
 
-                // The compilation classpath doesn't include the transitive dependencies
-                // So we use the runtime classpath to get complete type information
+                // The compilation classpath is required for things like Lombok which has
+                // annotations with source retention only.
                 List<Path> dependencyPathsNonFinal;
                 try {
-                    dependencyPathsNonFinal = sourceSet.getRuntimeClasspath().getFiles().stream()
+                    dependencyPathsNonFinal = Stream.concat(
+                                    sourceSet.getRuntimeClasspath().getFiles().stream(),
+                                    sourceSet.getCompileClasspath().getFiles().stream())
                             .map(File::toPath)
                             .map(Path::toAbsolutePath)
                             .map(Path::normalize)

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -686,8 +686,9 @@ public class DefaultProjectParser implements GradleProjectParser {
                         .filter(it -> it.toString().endsWith(".java") && !alreadyParsed.contains(it))
                         .collect(toList());
 
-                // The compilation classpath is required for things like Lombok which has
-                // annotations with source retention only.
+                // The compilation classpath doesn't include the transitive dependencies
+                // The runtime classpath doesn't include compile only dependencies, e.g.: lombok, servlet-api
+                // So we use both together to get comprehensive type information
                 List<Path> dependencyPathsNonFinal;
                 try {
                     dependencyPathsNonFinal = Stream.concat(


### PR DESCRIPTION
This commit reverts 8868dcff30f63511725961220e977d3d985d134c again. The compile classpath entries can contain important dependencies like Lombok, which typically don't exist on the runtime classpath.
