### PR TITLE
Add auto JDK download

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include("metrics")
 plugins {
     id("com.gradle.enterprise") version "3.16.1"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "1.12.1"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 gradleEnterprise {


### PR DESCRIPTION
I have NixOS and no JDK17 installed. Therefore, I get 

```
org.gradle.api.internal.provider.AbstractProperty$PropertyQueryException: Failed to calculate the value of task ':plugin:compileJava' property 'javaCompiler'.
...
Caused by: org.gradle.jvm.toolchain.internal.NoToolchainAvailableException: No matching toolchains found for requested specification: {languageVersion=17, vendor=any, implementation=vendor-specific} for LINUX on x86_64.
...
Caused by: org.gradle.jvm.toolchain.internal.ToolchainDownloadFailedException: No locally installed toolchains match and toolchain download repositories have not been configured.
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.tryInstall(DefaultJavaToolchainProvisioningService.java:110)
```

This can easily be solved with an auto JDK download:

https://github.com/gradle/foojay-toolchains#foojay-toolchains-plugin

---

I searched the issue list and did not find "foojay". Thus, I do not know if there is an [ADR](https://adr.github.io/) on that.

Hope, you like it!