### PR TITLE
Add test for issue 261

### DIFF
--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
@@ -135,14 +135,14 @@ class RewriteDryRunTest : RewritePluginTest {
                     id("java")
                     id("org.openrewrite.rewrite")
                 }
-                
+
                 repositories {
                     mavenCentral()
                     maven {
                        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
                     }
                 }
-                
+
                 dependencies {
                     implementation 'org.slf4j:slf4j-api:2.0.11'
                 }


### PR DESCRIPTION
This adds two small test for issue openrewrite/rewrite#4054.

This is just an outline.

It resembles the MWE at https://github.com/koppor/mwe-openrewrite-rewrite-gradle-plugin-issue-261/.

**However,** here, all `.java` types can be determined. (Independent of a rewrite.yml is used or not)

The test fail, because type information in `build.gradle` is missing.

This PR is only made to enable discussions of debuggin the issue.