### PR TITLE
Switch to JavaPluginExtension

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -211,7 +211,7 @@ tasks.named<Test>("test") {
 }
 
 val testGradle4 = tasks.register<Test>("testGradle4") {
-    systemProperty("org.openrewrite.test.gradleVersion", "4.0")
+    systemProperty("org.openrewrite.test.gradleVersion", "4.10")
     systemProperty("jarLocationForTest", tasks.named<Jar>("jar").get().archiveFile.get().asFile.absolutePath)
     // Gradle 4.0 predates support for Java 11
     javaLauncher.set(javaToolchains.launcherFor {

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -20,7 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
 import org.gradle.api.plugins.quality.CheckstylePlugin;
 
@@ -97,10 +97,8 @@ public class RewritePlugin implements Plugin<Project> {
             }
 
             //Collect Java metadata for each project (used for Java Provenance)
-            //Using the older javaConvention because we need to support older versions of gradle.
-            @SuppressWarnings("deprecation")
-            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-            javaConvention.getSourceSets().all(sourceSet -> {
+            JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            javaExtension.getSourceSets().all(sourceSet -> {
                 // This is intended to ensure that any Groovy/Kotlin/etc. and dependent project sources are available
                 Task compileTask = project.getTasks().getByPath(sourceSet.getCompileJavaTaskName());
                 rewriteRun.dependsOn(compileTask);
@@ -110,7 +108,7 @@ public class RewritePlugin implements Plugin<Project> {
             // Detect SourceSets which overlap other sourceSets and disable the compilation task of the overlapping
             // source set. Some plugins will create source sets not intended to be compiled for their own purposes.
             Set<String> sourceDirs = new HashSet<>();
-            project.afterEvaluate(unused -> javaConvention.getSourceSets().stream()
+            project.afterEvaluate(unused -> javaExtension.getSourceSets().stream()
                     .sorted(Comparator.comparingInt(sourceSet -> {
                         if ("main".equals(sourceSet.getName())) {
                             return 0;

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -28,7 +28,7 @@ import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.GroovyPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.service.ServiceRegistry;
@@ -275,7 +275,7 @@ public class DefaultProjectParser implements GradleProjectParser {
         // Use a sorted collection so that gradle input detection isn't thrown off by ordering
         Set<Path> result = new TreeSet<>(omniParser(emptySet(), project).acceptedPaths(baseDir, project.getProjectDir().toPath()));
         //noinspection deprecation
-        JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
+        JavaPluginExtension javaConvention = project.getConvention().findPlugin(JavaPluginExtension.class);
         if (javaConvention != null) {
             for (SourceSet sourceSet : javaConvention.getSourceSets()) {
                 sourceSet.getAllSource().getFiles().stream()
@@ -627,10 +627,10 @@ public class DefaultProjectParser implements GradleProjectParser {
             List<NamedStyles> styles = getStyles();
             logger.lifecycle("Using active styles {}", styles.stream().map(NamedStyles::getName).collect(toList()));
             @SuppressWarnings("deprecation")
-            JavaPluginConvention javaConvention = subproject.getConvention().findPlugin(JavaPluginConvention.class);
+            JavaPluginExtension javaExtension = subproject.getExtensions().findByType(JavaPluginExtension.class);
             List<SourceSet> sourceSets;
             List<Marker> projectProvenance;
-            if (javaConvention == null) {
+            if (javaExtension == null) {
                 projectProvenance = sharedProvenance;
                 sourceSets = emptyList();
             } else {
@@ -639,7 +639,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                         new JavaProject.Publication(subproject.getGroup().toString(),
                                 subproject.getName(),
                                 subproject.getVersion().toString())));
-                sourceSets = javaConvention.getSourceSets().stream()
+                sourceSets = javaExtension.getSourceSets().stream()
                         .sorted(Comparator.comparingInt(sourceSet -> {
                             if ("main".equals(sourceSet.getName())) {
                                 return 0;


### PR DESCRIPTION
As discussed replicating the same change here ; but I'm getting failures on Gradle 4.10.
```
java.lang.NoSuchMethodError: org.gradle.api.plugins.JavaPluginExtension.getSourceSets()Lorg/gradle/api/tasks/SourceSetContainer;
	at org.openrewrite.gradle.RewritePlugin.lambda$configureProject$5(RewritePlugin.java:101)
	at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:158)
	at org.openrewrite.gradle.RewritePlugin.configureProject(RewritePlugin.java:87)
	at org.openrewrite.gradle.RewritePlugin.lambda$apply$0(RewritePlugin.java:78)
	at org.gradle.api.internal.project.BuildOperationCrossProjectConfigurator$4.execute(BuildOperationCrossProjectConfigurator.java:108)
	at org.gradle.internal.Actions.with(Actions.java:245)
```