### PR TITLE
Fix for Java source file encoding different from UTF-8

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -30,6 +30,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.invocation.DefaultGradle;
@@ -97,6 +98,7 @@ import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
 import static org.openrewrite.PathUtils.separatorsToUnix;
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.tree.ParsingExecutionContextView.view;
 
 public class DefaultProjectParser implements GradleProjectParser {
     private static final String LOG_INDENT_INCREMENT = "    ";
@@ -289,7 +291,7 @@ public class DefaultProjectParser implements GradleProjectParser {
     }
 
     public void dryRun(Path reportPath, boolean dumpGcActivity, Consumer<Throwable> onError) {
-        ParsingExecutionContextView ctx = ParsingExecutionContextView.view(new InMemoryExecutionContext(onError));
+        ParsingExecutionContextView ctx = view(new InMemoryExecutionContext(onError));
         if (dumpGcActivity) {
             SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
             try (JvmHeapPressureMetrics heapMetrics = new JvmHeapPressureMetrics()) {
@@ -657,6 +659,8 @@ public class DefaultProjectParser implements GradleProjectParser {
                 sourceFileStream = sourceFileStream.concat(parseMultiplatformKotlinProject(subproject, exclusions, alreadyParsed, ctx));
             }
 
+            Charset sourceCharset = Charset.forName(System.getProperty("file.encoding", "UTF-8"));
+
             for (SourceSet sourceSet : sourceSets) {
                 Stream<SourceFile> sourceSetSourceFiles = Stream.of();
                 int sourceSetSize = 0;
@@ -667,6 +671,10 @@ public class DefaultProjectParser implements GradleProjectParser {
                         System.getProperty("java.vm.vendor"),
                         javaCompileTask.getSourceCompatibility(),
                         javaCompileTask.getTargetCompatibility());
+
+                CompileOptions compileOptions = javaCompileTask.getOptions();
+                final Charset javaSourceCharset = (compileOptions != null && compileOptions.getEncoding() != null)
+                        ? Charset.forName(compileOptions.getEncoding()) : sourceCharset;
 
                 List<Path> unparsedSources = sourceSet.getAllSource()
                         .getSourceDirectories()
@@ -709,6 +717,8 @@ public class DefaultProjectParser implements GradleProjectParser {
                 List<Path> dependencyPaths = dependencyPathsNonFinal;
 
                 if (!javaPaths.isEmpty()) {
+                    view(ctx).setCharset(javaSourceCharset);
+
                     alreadyParsed.addAll(javaPaths);
                     Stream<SourceFile> cus = Stream
                             .of((Supplier<JavaParser>) () -> JavaParser.fromJavaVersion()

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
@@ -17,6 +17,8 @@ package org.openrewrite.gradle
 
 import org.intellij.lang.annotations.Language
 import java.io.File
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 /**
  * Utility to help with writing gradle projects to disk to assist with plugin testing
@@ -68,8 +70,11 @@ class GradleProjectSpec(
         return subproject
     }
 
-    fun sourceSet(name: String, init: GradleSourceSetSpec.()->Unit): GradleSourceSetSpec {
-        val sourceSet = GradleSourceSetSpec(name).apply(init)
+    fun sourceSet(name: String,
+                  sourceCharset: Charset = StandardCharsets.UTF_8,
+                  resourceCharset: Charset = StandardCharsets.UTF_8,
+                  init: GradleSourceSetSpec.()->Unit): GradleSourceSetSpec {
+        val sourceSet = GradleSourceSetSpec(name, sourceCharset, resourceCharset).apply(init)
         sourceSets.add(sourceSet)
         return sourceSet
     }
@@ -130,7 +135,9 @@ class GradleProjectSpec(
 }
 
 class GradleSourceSetSpec(
-    private val name: String
+    private val name: String,
+    private val sourceCharset: Charset = StandardCharsets.UTF_8,
+    private val resourceCharset: Charset = StandardCharsets.UTF_8
 ) {
     private val javaSources: MutableList<String> = mutableListOf()
     fun java(@Language("java") source: String) {
@@ -177,7 +184,7 @@ class GradleSourceSetSpec(
             }
             File(dir, path).apply{
                 parentFile.mkdirs()
-                writeText(javaSource)
+                writeText(javaSource, sourceCharset)
             }
         }
         for (kotlinSource in kotlinSources) {
@@ -196,7 +203,7 @@ class GradleSourceSetSpec(
             }
             File(dir, path).apply{
                 parentFile.mkdirs()
-                writeText(kotlinSource)
+                writeText(kotlinSource, sourceCharset)
             }
         }
         for (groovySource in groovyClasses) {
@@ -215,14 +222,14 @@ class GradleSourceSetSpec(
             }
             File(dir, path).apply{
                 parentFile.mkdirs()
-                writeText(groovySource)
+                writeText(groovySource, sourceCharset)
             }
         }
         if (propertiesFiles.isNotEmpty()) {
             for (props in propertiesFiles.entries) {
                 File(dir, "$name/resources/${props.key}").apply{
                     parentFile.mkdirs()
-                    writeText(props.value)
+                    writeText(props.value, resourceCharset)
                 }
             }
         }
@@ -230,7 +237,7 @@ class GradleSourceSetSpec(
             for (yaml in yamlFiles.entries) {
                 File(dir, "$name/resources/${yaml.key}").apply{
                     parentFile.mkdirs()
-                    writeText(yaml.value)
+                    writeText(yaml.value, resourceCharset)
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
Fixes #285 

## What's changed?
<!-- A brief description of the changes in this pull request -->
rewriteRun now respects the file encoding of the Gradle Java Plugin

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
