### PR TITLE
Stop using JavaPluginConvention for Gradle 7.1+

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -21,8 +21,10 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
 import org.gradle.api.plugins.quality.CheckstylePlugin;
+import org.gradle.api.tasks.SourceSetContainer;
 
 import java.io.File;
 import java.util.Comparator;
@@ -98,10 +100,16 @@ public class RewritePlugin implements Plugin<Project> {
             }
 
             //Collect Java metadata for each project (used for Java Provenance)
-            //Using the older javaConvention because we need to support older versions of gradle.
-            @SuppressWarnings("deprecation")
-            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-            javaConvention.getSourceSets().all(sourceSet -> {
+            SourceSetContainer sourceSets;
+            if (project.getGradle().getGradleVersion().compareTo("7.1") >= 0) {
+                sourceSets = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
+            } else {
+                //Using the older javaConvention because we need to support older versions of gradle.
+                @SuppressWarnings("deprecation")
+                JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+                sourceSets = javaConvention.getSourceSets();
+            }
+            sourceSets.all(sourceSet -> {
                 // This is intended to ensure that any Groovy/Kotlin/etc. and dependent project sources are available
                 Task compileTask = project.getTasks().getByPath(sourceSet.getCompileJavaTaskName());
                 rewriteRun.dependsOn(compileTask);
@@ -111,7 +119,7 @@ public class RewritePlugin implements Plugin<Project> {
             // Detect SourceSets which overlap other sourceSets and disable the compilation task of the overlapping
             // source set. Some plugins will create source sets not intended to be compiled for their own purposes.
             Set<String> sourceDirs = new HashSet<>();
-            project.afterEvaluate(unused -> javaConvention.getSourceSets().stream()
+            project.afterEvaluate(unused -> sourceSets.stream()
                     .sorted(Comparator.comparingInt(sourceSet -> {
                         if ("main".equals(sourceSet.getName())) {
                             return 0;

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -29,7 +29,9 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.invocation.DefaultGradle;
@@ -279,10 +281,9 @@ public class DefaultProjectParser implements GradleProjectParser {
     public Collection<Path> listSources() {
         // Use a sorted collection so that gradle input detection isn't thrown off by ordering
         Set<Path> result = new TreeSet<>(omniParser(emptySet(), project).acceptedPaths(baseDir, project.getProjectDir().toPath()));
-        //noinspection deprecation
-        JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
-        if (javaConvention != null) {
-            for (SourceSet sourceSet : javaConvention.getSourceSets()) {
+        SourceSetContainer sourceSets = findSourceSetContainer(project);
+        if (sourceSets != null) {
+            for (SourceSet sourceSet : sourceSets) {
                 sourceSet.getAllSource().getFiles().stream()
                         .map(File::toPath)
                         .map(Path::toAbsolutePath)
@@ -633,11 +634,10 @@ public class DefaultProjectParser implements GradleProjectParser {
             logger.lifecycle("Scanning sources in project {}", subproject.getPath());
             List<NamedStyles> styles = getStyles();
             logger.lifecycle("Using active styles {}", styles.stream().map(NamedStyles::getName).collect(toList()));
-            @SuppressWarnings("deprecation")
-            JavaPluginConvention javaConvention = subproject.getConvention().findPlugin(JavaPluginConvention.class);
+            SourceSetContainer sourceSetContainer = findSourceSetContainer(subproject);
             List<SourceSet> sourceSets;
             List<Marker> projectProvenance;
-            if (javaConvention == null) {
+            if (sourceSetContainer == null) {
                 projectProvenance = sharedProvenance;
                 sourceSets = emptyList();
             } else {
@@ -646,7 +646,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                         new JavaProject.Publication(subproject.getGroup().toString(),
                                 subproject.getName(),
                                 subproject.getVersion().toString())));
-                sourceSets = javaConvention.getSourceSets().stream()
+                sourceSets = sourceSetContainer.stream()
                         .sorted(Comparator.comparingInt(sourceSet -> {
                             if ("main".equals(sourceSet.getName())) {
                                 return 0;
@@ -1286,5 +1286,24 @@ public class DefaultProjectParser implements GradleProjectParser {
         for (RecipeDescriptor rChild : rd.getRecipeList()) {
             logRecipe(rChild, prefix + "    ");
         }
+    }
+
+    @Nullable
+    private SourceSetContainer findSourceSetContainer(Project project) {
+        SourceSetContainer sourceSets = null;
+        if (project.getGradle().getGradleVersion().compareTo("7.1") >= 0) {
+            JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
+            if (javaPluginExtension != null) {
+                sourceSets = javaPluginExtension.getSourceSets();
+            }
+        } else {
+            //Using the older javaConvention because we need to support older versions of gradle.
+            @SuppressWarnings("deprecation")
+            JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
+            if (javaConvention != null) {
+                sourceSets = javaConvention.getSourceSets();
+            }
+        }
+        return sourceSets;
     }
 }


### PR DESCRIPTION
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation

Fixes #307
