### PR TITLE
adding nebula.maven-apache-license plugin to inject license metadata …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("org.owasp.dependencycheck") version "latest.release" apply false
     id("nebula.maven-resolved-dependencies") version "18.4.0" apply false
+    id("nebula.maven-apache-license") version "18.4.0" apply false
 }
 
 configure<nebula.plugin.release.git.base.ReleasePluginExtension> {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     kotlin("jvm") version("1.9.0")
     id("com.gradle.plugin-publish") version "1.1.0"
     id("com.github.hierynomus.license") version "0.16.1"
+    id("nebula.maven-apache-license")
 }
 
 gradlePlugin {


### PR DESCRIPTION
…into plugin's pom

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The plugin's generated pom (but not necessarily the plugin marker artifact) should now include the license metadata

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
#305

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
