### PR TITLE
Add ability to export dataTables

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -35,6 +35,16 @@ public class RewriteExtension {
     private final List<String> activeStyles = new ArrayList<>();
     private boolean configFileSetDeliberately;
 
+    public boolean isExportDatatables() {
+        return exportDatatables;
+    }
+
+    public void setExportDatatables(boolean exportDatatables) {
+        this.exportDatatables = exportDatatables;
+    }
+
+    private boolean exportDatatables;
+
     protected final Project project;
     private File configFile;
 

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -35,16 +35,6 @@ public class RewriteExtension {
     private final List<String> activeStyles = new ArrayList<>();
     private boolean configFileSetDeliberately;
 
-    public boolean isExportDatatables() {
-        return exportDatatables;
-    }
-
-    public void setExportDatatables(boolean exportDatatables) {
-        this.exportDatatables = exportDatatables;
-    }
-
-    private boolean exportDatatables;
-
     protected final Project project;
     private File configFile;
 
@@ -53,6 +43,7 @@ public class RewriteExtension {
     private File checkstyleConfigFile;
     private String metricsUri = magicalMetricsLogString;
     private boolean enableExperimentalGradleBuildScriptParsing = true;
+    private boolean exportDatatables;
     private final List<String> exclusions = new ArrayList<>();
     private final List<String> plainTextMasks = new ArrayList<>();
 
@@ -286,6 +277,14 @@ public class RewriteExtension {
 
     public void setEnableExperimentalGradleBuildScriptParsing(boolean enableExperimentalGradleBuildScriptParsing) {
         this.enableExperimentalGradleBuildScriptParsing = enableExperimentalGradleBuildScriptParsing;
+    }
+
+    public boolean isExportDatatables() {
+        return exportDatatables;
+    }
+
+    public void setExportDatatables(boolean exportDatatables) {
+        this.exportDatatables = exportDatatables;
     }
 
     public List<String> getExclusions() {

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -89,6 +89,8 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -1255,6 +1257,14 @@ public class DefaultProjectParser implements GradleProjectParser {
 
         logger.lifecycle("All sources parsed, running active recipes: {}", String.join(", ", getActiveRecipes()));
         RecipeRun recipeRun = recipe.run(new InMemoryLargeSourceSet(sourceFiles), ctx);
+
+        if (extension.isExportDatatables()) {
+            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"));
+            Path datatableDirectoryPath = Paths.get(baseDir.toString(), "build", "rewrite", "datatables", timestamp);
+            logger.info(String.format("Printing Available Datatables to: %s", datatableDirectoryPath));
+            recipeRun.exportDatatablesToCsv(datatableDirectoryPath, ctx);
+        }
+
         return new ResultsContainer(baseDir, recipeRun);
     }
 

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1261,7 +1261,7 @@ public class DefaultProjectParser implements GradleProjectParser {
         if (extension.isExportDatatables()) {
             String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"));
             Path datatableDirectoryPath = Paths.get(baseDir.toString(), "build", "rewrite", "datatables", timestamp);
-            logger.info(String.format("Printing Available Datatables to: %s", datatableDirectoryPath));
+            logger.info(String.format("Printing available datatables to: %s", datatableDirectoryPath));
             recipeRun.exportDatatablesToCsv(datatableDirectoryPath, ctx);
         }
 


### PR DESCRIPTION
## What's changed?
Added the ability to export data tables.

## What's your motivation?
I was reading about them in the docs and found that they were only implemented in maven and there was a request to add them to the gradle plugin. 

I did see that this open issue that talks about adding some configuration that would allow you more control over turning certain csv exports on or off. From a cursory look, it seems like I might have to change rewrite-core for that to work. I'm not opposed to doing that, but I thought I'd create this PR to get thoughts before moving too far forward.

I did not add any tests yet either. I'll be more than happy to update this to a prod-ready state.

I added to the `RewriteExtension`:

```
rewrite {
    exportDatatables = true
}

```

It defaults to false.

Here's a screenshot of the cvs file output:
![image](https://github.com/user-attachments/assets/cfb3c974-879d-465f-9c4d-cc8ee6f15468)


## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?

## Any additional context

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
