### PR TITLE
Add JavaVersion marker to files in Java project resources directories

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -826,7 +826,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                         sourceSetSourceFiles = Stream.concat(
                                 sourceSetSourceFiles,
                                 omniParser.parse(accepted, baseDir, new InMemoryExecutionContext())
-                        );
+                        ).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
                         alreadyParsed.addAll(accepted);
                         sourceSetSize += accepted.size();
                     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add JavaVersion marker to files in Java project resources directories

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
For parity with the [Maven plugin](https://github.com/openrewrite/rewrite-maven-plugin/blob/f1711dc2d1dff52d089248b7f6376bd361d96896/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java#L421-L435) which adds the JavaVersion marker also to files in Java resources directories.
Without this fix, for example, the [EnableVirtualThreads](https://github.com/openrewrite/rewrite-spring/blob/1572696591829a8be8d9d85ed440354bc8bd1892/src/main/resources/META-INF/rewrite/spring-boot-32.yml#L69-L79) recipe does no changes if executed via the Gradle plugin, while the Maven plugin performs the expected changes:

**Maven Plugin:**
```console
[INFO] --- rewrite:5.36.0:run (default-cli) @ java-version-marker ---
[INFO] Using active recipe(s) [org.openrewrite.java.spring.boot3.EnableVirtualThreads]
[INFO] Using active styles(s) []
[INFO] Validating active recipes...
[INFO] Project [java-version-marker] Resolving Poms...
[INFO] Project [java-version-marker] Parsing source files
[INFO] Running recipe(s)...
[INFO] Printing Available Datatables to: target/rewrite/datatables/2024-07-29_19-05-16-717
[WARNING] Changes have been made to java-version-marker/src/main/resources/application.properties by:
[WARNING]     org.openrewrite.java.spring.boot3.EnableVirtualThreads
[WARNING]         org.openrewrite.java.spring.AddSpringProperty: {property=spring.threads.virtual.enabled, value=true}
[WARNING] Please review and commit the results.
[WARNING] Estimate time saved: 5m
```


**Gradle Plugin:**
```console
> Task :rewriteRun
Validating active recipes
Scanning sources in project :
Using active styles []
All sources parsed, running active recipes: org.openrewrite.java.spring.boot3.EnableVirtualThreads

BUILD SUCCESSFUL in 3s
```
Example project: https://github.com/gideon-sunbit/openrewrite-examples-public/tree/main/java-version-marker

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
