### PR TITLE
Look for ParseExceptionResult marker instead of instanceof ParserError

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -73,7 +73,6 @@ import org.openrewrite.quark.QuarkParser;
 import org.openrewrite.remote.Remote;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.text.PlainTextParser;
-import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 import org.openrewrite.xml.tree.Xml;
@@ -1152,12 +1151,13 @@ public class DefaultProjectParser implements GradleProjectParser {
     }
 
     private SourceFile logParseErrors(SourceFile source) {
-        if (source instanceof ParseError) {
+        source.getMarkers().findFirst(ParseExceptionResult.class).ifPresent(e ->  {
             if (firstWarningLogged.compareAndSet(false, true)) {
                 logger.warn("There were problems parsing some source files, run with --info to see full stack traces");
             }
             logger.warn("There were problems parsing " + source.getSourcePath());
-        }
+            logger.debug(e.getMessage());
+        });
         return source;
     }
 


### PR DESCRIPTION
## What's changed?
Previously we looked at `source instanceof ParseError`, but there might be cases in the future where a file parsed correctly, but got assigned a marker for a different reason. Up to now that had been exclusive to Maven files, but figured it good to support here as well.

## What's your motivation?
Over on the Maven side we saw files silently having error markers, with no indication that they failed to resolve. This ensures if that happens for files that show in the Gradle side of things then we are ready to show those here as well.

## Any additional context
- Mimics https://github.com/openrewrite/rewrite-maven-plugin/pull/833
