### PR TITLE
Do not add Kotlin and Groovy sources from `build/` to LST

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -750,10 +750,12 @@ public class DefaultProjectParser implements GradleProjectParser {
                 }
 
                 if (subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.jvm")) {
+                    String excludedBuildSrcPath = subproject.getProjectDir().getPath() + "/build/generated-sources";
                     String excludedProtosPath = subproject.getProjectDir().getPath() + "/protos/build/generated";
                     List<Path> kotlinPaths = unparsedSources.stream()
-                            .filter(it -> !it.toString().startsWith(excludedProtosPath))
                             .filter(it -> it.toString().endsWith(".kt"))
+                            .filter(it -> !it.toString().startsWith(excludedBuildSrcPath))
+                            .filter(it -> !it.toString().startsWith(excludedProtosPath))
                             .collect(toList());
 
                     if (!kotlinPaths.isEmpty()) {


### PR DESCRIPTION
## What's changed?
Reuse the mechanism we added for `protos/build/generated` for `build/generated-sources`.

## What's your motivation?
Files like `build-src/build/generated-sources` are parsed into the LST, and modified by recipes. That last part is undesirable, as the diffs would then target files not part of the git repository, and fail to apply from a dryRun fix.patch file.

n | sourcePath | sourceFileType | buildTool | buildToolVersion | checksum | lineCount
-- | -- | -- | -- | -- | -- | --
1 | build-src/build/generated-sources/kotlin-dsl-external-plugin-spec-builders/kotlin/gradle/kotlin/dsl/plugins/_12895b5fa930feaf40eec89923f04a18/PluginSpecBuilders.kt | K.CompilationUnit | modgradle | 3.17.0 | 55d3a6f819a2d911e8dc50fcdba328c6 | 1186
2 | build-src/build/generated-sources/kotlin-dsl-accessors/kotlin/gradle/kotlin/dsl/accessors/_f68e08f112e4a379392eaca54506dc98/Accessorsct2ylp5ktt4rxe14s34wgi9de.kt | K.CompilationUnit | modgradle | 3.17.0 | f4d3580d463adfe088c5cc21c590086f | 76
3 | build-src/build/generated-sources/kotlin-dsl-accessors/kotlin/gradle/kotlin/dsl/accessors/_f68e08f112e4a379392eaca54506dc98/Accessorsd6fwhfk2ip9kv56d7w2vygrh6.kt | K.CompilationUnit | modgradle | 3.17.0 | 1a203f1b9aaeb9223e2565c7cd25fa37 | 76


## Anything in particular you'd like reviewers to focus on?
There's likely a better way, but I'm having a bit of trouble working that out. Figured open this PR to start the discussion.

## Have you considered any alternatives or workarounds?
What I'd done previously in an attempt to exclude these files is add them to Git ignore:
https://github.com/openrewrite/rewrite-recipe-bom/commit/9f5840cc1d8d8b4f4795546b95c8242622d6c116
But somehow they are still picked up; I had thought we already excluded files ignored in git.

## Any additional context
I know in the Maven plugin we explicitly exclude generated sources, but I'm not immediately seeing an equivalent here.
https://github.com/ammachado/rewrite-maven-plugin/blob/f900a9a6365a4d02c0083dd29e14927d6ffa6576/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java#L425-L430