### PR TITLE
Fail hard on failure to resolve dependencies

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1303,9 +1303,9 @@ public class DefaultProjectParser implements GradleProjectParser {
                 try {
                     implementationClasspath = rewriteImplementation.resolve();
                 } catch (Exception e) {
-                    logger.warn("Failed to resolve dependencies from {}:{}. Some type information may be incomplete",
-                            subproject.getPath(), implementationName);
-                    implementationClasspath = emptySet();
+                    throw new RuntimeException(String.format("Failed to resolve the dependencies from %s:%s; " +
+                                    "We can not reliably continue without this information.",
+                            subproject.getPath(), implementationName), e);
                 }
 
                 String compileName = (String) sourceSet.getClass().getMethod("getCompileOnlyConfigurationName").invoke(sourceSet);

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -30,6 +31,7 @@ import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.service.ServiceRegistry;
@@ -1303,7 +1305,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                 try {
                     implementationClasspath = rewriteImplementation.resolve();
                 } catch (Exception e) {
-                    throw new RuntimeException(String.format("Failed to resolve the dependencies from %s:%s; " +
+                    throw new GradleException(String.format("Failed to resolve the dependencies from %s:%s; " +
                                     "We can not reliably continue without this information.",
                             subproject.getPath(), implementationName), e);
                 }


### PR DESCRIPTION
## What's changed?
Fail hard on failure to resolve dependencies, as opposed to continuing with partial type information.

## What's your motivation?
Partial type information can lead to missing changes, and hard to trouble shoot issues. We'd rather fail fast and hard, such that the underlying issues can be addressed.

## Anything in particular you'd like reviewers to focus on?
Not too familiar with Gradle plugin development; throwing a GradleException seemed the best fit to achieve something similar to [what we did in the Maven plugin](https://github.com/openrewrite/rewrite-maven-plugin/compare/f59215908381abfd4fbdea116b442f58752292a2...59404e58d219ab900ff3787497cf148f53253ac8).