### PR TITLE
Change output directory path for Datatables

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1396,7 +1396,7 @@ public class DefaultProjectParser implements GradleProjectParser {
 
         if (extension.isExportDatatables()) {
             String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"));
-            Path datatableDirectoryPath = Paths.get(baseDir.toString(), "build", "rewrite", "datatables", timestamp);
+            Path datatableDirectoryPath = project.getLayout().getBuildDirectory().dir("reports/rewrite/datatables/" + timestamp).get().getAsFile().toPath();
             logger.info(String.format("Printing available datatables to: %s", datatableDirectoryPath));
             recipeRun.exportDatatablesToCsv(datatableDirectoryPath, ctx);
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Change output directory for datatables from `<repository top directory>/build/rewrite/datatables` to `<gradle project directory>/build/reports/rewrite/datatables`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Currently, when `setExportDatatables()` is set to `true`, the CSV files are exported to `<repository top directory>/build/datatables`. However, I believe it would be better to change the output to the `build` directory of each Gradle projects for the following two reasons.

1. If the Gradle project's directory is different from the repository's top directory, the CSV files will not be deleted when the `clean` task is executed.
2. In a multi-project structure built with Gradle, it is easier to understand the relevance if the CSV files are output to the `build` directory of each project.

Files related to reports output during the execution of Gradle tasks are conventionally output to `<gradle project directory>/build/reports`. Also, considering that the patch file generated when executing the `rewriteDryRun` task is output to `build/reports/rewrite/rewrite.patch`, I propose changing the output directory to `<gradle project directory>/build/reports/rewrite/datatables`.

- Fixes #341

```terminal
<Repository Top Directory>
+---build
|   \---rewrite
|       \---datatables // Currennt output directory
|
+---GradleTop
|   +---.gradle
|   +---app
|   |   +---build
|   |   |   +---classes
|   |   |   |   \---java
|   |   |   |       +---main
|   |   |   |       \---test
|   |   |   +---distributions
|   |   |   +---generated
|   |   |   +---libs
|   |   |   +---reports
|   |   |   |   +---rewrite
|   |   |   |   |   |   rewrite.patch
|   |   |   |   |   |
|   |   |   |   |   \---datatables // new output directory proposed
|   |   |   |   \---tests
|   |   |   +---scripts
|   |   |   +---test-results
|   |   |   \---tmp
|   |   \---src
|   |
|   +---buildSrc
|   |   +---.gradle
|   |   +---build
|   |   \---src
|   |
|   +---gradle
|   |   \---wrapper
|   \---utilities
|       +---build
|       |   +---classes
|       |   |   \---java
|       |   |       \---main
|       |   +---generated
|       |   +---libs
|       |   +---reports
|       |   |   +---rewrite
|       |   |   |   |   rewrite.patch
|       |   |   |   |
|       |   |   |   \---datatables // new output directory proposed
|       |   \---tmp
|       \---src
|           +---main
|           |   +---java
|           |   \---resources
|           \---test
|               \---resources
+---otherDirA
\---otherDirB
```

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files


