### PR TITLE
Simplify Plugins approach to adding dependencies so that it no longer uses a hidden detached configuration.

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -73,9 +73,9 @@ public class RewritePlugin implements Plugin<Project> {
 
         // Rewrite module dependencies put here will be available to all rewrite tasks
         Configuration rewriteConf = project.getConfigurations().maybeCreate("rewrite");
-        rewriteConf.getDependencies().addAllLater(
-                project.provider(() -> knownRewriteDependencies(extension, project.getDependencies()))
-        );
+        knownRewriteDependencies(extension, project.getDependencies()).forEach(dep -> {
+            rewriteConf.getDependencies().addLater(project.provider(() -> dep));
+        });
 
         // Because of how this Gradle has no criteria with which to select between variants of
         // dependencies which expose differing capabilities. So those must be manually configured

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -1452,7 +1452,7 @@ class RewriteRunTest : RewritePluginTest {
                   - org.openrewrite.gradle.UpgradeDependencyVersion:
                       groupId: com.fasterxml.jackson.core
                       artifactId: jackson-databind
-                      version: 2.18.0
+                      newVersion: 2.18.0
             """)
             buildGradle("""
                 plugins {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Removed dependency copying out of the `rewrite` configuration to a hidden detached one.

## What's your motivation?
We have internal tooling that relies on being able to attach to configurations with a `beforeResolve` hook override dependencies and provide centralized dependency versioning. With the detached configuration there is not way to attach the hook and dependency resolution fails. By removing the detached configuration in favor of the `rewrite` configuration we should be able to use normal hooks as expected.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
We've attempted several approaches without modifying the existing plugin but each has run into subtle problems.
* Resolving our internal dependencies first (currently a library of internal recipes) and injecting the resovled files as dependencies. - Lead to duplicated jars on the classpath.
* Replacing the dependencies provider externally with one we can control. - There's no way to get a list of the dependencies the plugin adds without reflectively changing access levels, other forms of nastiness, or repeating the first problem but from the opposite side.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- ~~[ ] I've added unit tests to cover both positive and negative cases~~ _Existing test cases already cover the behavior and the expected behavior should not change._
- [/] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [/] I've used the IntelliJ IDEA auto-formatter on affected files
