### PR TITLE
Apply MSAL license when generating POMs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("org.owasp.dependencycheck") version "10.+" apply false
     id("nebula.maven-resolved-dependencies") version "18.4.0" apply false
-    id("nebula.maven-apache-license") version "18.4.0" apply false
+    id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
 }
 
 configure<nebula.plugin.release.git.base.ReleasePluginExtension> {


### PR DESCRIPTION
The license should be included in POMs being published to Maven Central