### PR TITLE
Reuse ExecutionContext with onError for Omniparser

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
@@ -172,7 +172,7 @@ class AndroidProjectParser {
                                         .collect(Collectors.toSet());
                         sourceSetSourceFiles = Stream.concat(
                                 sourceSetSourceFiles,
-                                omniParser.parse(accepted, baseDir, new InMemoryExecutionContext())
+                                omniParser.parse(accepted, baseDir, ctx)
                                         .map(it -> it.withMarkers(it.getMarkers().add(javaVersion))));
                         alreadyParsed.addAll(accepted);
                         sourceSetSize += accepted.size();

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -881,7 +881,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                     List<Path> accepted = omniParser.acceptedPaths(baseDir, resourcesDir.toPath());
                     sourceSetSourceFiles = Stream.concat(
                             sourceSetSourceFiles,
-                            omniParser.parse(accepted, baseDir, new InMemoryExecutionContext())
+                            omniParser.parse(accepted, baseDir, ctx)
                                     .map(it -> it.withMarkers(it.getMarkers().add(javaVersion))));
                     alreadyParsed.addAll(accepted);
                     sourceSetSize += accepted.size();


### PR DESCRIPTION
To avoid swallowing throwables from parsers.