### PR TITLE
chore: update org.owasp.dependencycheck to latest.release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("nebula.release") version "17.1.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.owasp.dependencycheck") version "10.+" apply false
+    id("org.owasp.dependencycheck") version "latest.release" apply false
     id("nebula.maven-resolved-dependencies") version "18.4.0" apply false
     id("nebula.maven-apache-license") version "18.4.0" apply false
 }

--- a/metrics/build.gradle.kts
+++ b/metrics/build.gradle.kts
@@ -32,6 +32,14 @@ dependencies {
     api("io.micrometer.prometheus:prometheus-rsocket-client:latest.release")
     api("io.rsocket:rsocket-transport-netty:latest.release")
 
+    constraints {
+        // prometheus-rsocket-client depends on this
+        // @see https://github.com/xerial/snappy-java/releases/tag/v1.1.10.4
+        api("org.xerial.snappy:snappy-java:1.1.10.4") {
+            because("CVE-2023-43642")
+        }
+    }
+
     implementation(platform("io.netty:netty-bom:latest.release"))
     implementation("io.projectreactor.netty:reactor-netty-core:latest.release")
     implementation("io.projectreactor.netty:reactor-netty-http:latest.release")


### PR DESCRIPTION
re: https://github.com/moderneinc/dependency-vulnerability-reports/issues/820