### PR TITLE
Add test cases for verifying custom source set handling

### DIFF
--- a/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle
 
 import org.gradle.testkit.runner.BuildResult

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
@@ -1,0 +1,49 @@
+package org.openrewrite.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
+import java.io.File
+import java.lang.management.ManagementFactory
+
+val gradleVersion: String? = System.getProperty("org.openrewrite.test.gradleVersion")
+
+interface GradleRunnerTest {
+
+    fun runGradle(testDir: File, vararg args: String): BuildResult {
+        return GradleRunner.create()
+            .withDebug(ManagementFactory.getRuntimeMXBean().inputArguments.toString().indexOf("-agentlib:jdwp") > 0)
+            .withProjectDir(testDir)
+            .apply {
+                if (gradleVersion != null) {
+                    withGradleVersion(gradleVersion)
+                }
+            }
+            .withArguments(*args, "--info", "--stacktrace")
+            .withPluginClasspath()
+            .forwardOutput()
+            .build()
+    }
+
+    fun lessThanGradle6_1(): Boolean {
+        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
+        return currentVersion < GradleVersion.version("6.1")
+    }
+
+    fun lessThanGradle6_8(): Boolean {
+        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
+        return currentVersion < GradleVersion.version("6.8")
+    }
+
+    fun lessThanGradle7_4(): Boolean {
+        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
+        return currentVersion < GradleVersion.version("7.4")
+    }
+
+    fun isAgp3CompatibleGradleVersion(): Boolean {
+        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
+        return System.getenv("ANDROID_HOME") != null &&
+                currentVersion >= GradleVersion.version("5.0") &&
+                currentVersion < GradleVersion.version("8.0")
+    }
+}

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunSourceSetTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunSourceSetTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle
 
 import org.assertj.core.api.Assertions.assertThat

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunSourceSetTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunSourceSetTest.kt
@@ -1,0 +1,236 @@
+package org.openrewrite.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.REWRITE_BUILD_GRADLE
+import org.openrewrite.gradle.fixtures.JavaFixtures.Companion.HELLO_WORLD_JAVA_CLASS
+import org.openrewrite.gradle.fixtures.JavaFixtures.Companion.HELLO_WORLD_JAVA_INTERFACE
+import java.io.File
+
+class RewriteDryRunSourceSetTest : GradleRunnerTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    companion object {
+        const val TASK_NAME = "rewriteDryRun"
+        const val DEFAULT_SRC_DIR = "src/main/java"
+        const val DEFAULT_RESOURCES_DIR = "src/main/resources"
+        const val CUSTOM_SRC_DIR = "src"
+        const val CUSTOM_RESOURCES_DIR = "resources"
+
+        //language=yaml
+        const val REWRITE_YAML =
+            """
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.gradle.ChangePackage
+            description: Test.
+            recipeList:
+              - org.openrewrite.java.ChangePackage:
+                  oldPackageName: org.openrewrite.before
+                  newPackageName: org.openrewrite.after
+            """
+
+        //language=groovy
+        const val REWRITE_PLUGIN_ACTIVE_RECIPE = """
+            rewrite {
+                activeRecipe("org.openrewrite.gradle.ChangePackage", "org.openrewrite.java.format.AutoFormat")
+            }
+        """
+    }
+
+    @Test
+    fun `can use default source set directories`() {
+        gradleProject(projectDir) {
+            rewriteYaml(REWRITE_YAML)
+            buildGradle(
+                REWRITE_BUILD_GRADLE +
+                REWRITE_PLUGIN_ACTIVE_RECIPE
+            )
+
+            sourceSet("main") {
+                java(HELLO_WORLD_JAVA_INTERFACE)
+                java(HELLO_WORLD_JAVA_CLASS)
+                yamlFile(
+                    "foo.yml", "foo: bar"
+                )
+            }
+        }
+
+        val result = runGradle(projectDir, TASK_NAME)
+
+        assertTaskOutcome(result)
+        assertPatchFileContents(DEFAULT_SRC_DIR)
+    }
+
+    @Test
+    fun `can use only custom Java source set directory`() {
+        gradleProject(projectDir) {
+            rewriteYaml(REWRITE_YAML)
+            buildGradle(
+                REWRITE_BUILD_GRADLE +
+                        REWRITE_PLUGIN_ACTIVE_RECIPE +
+                        //language=groovy
+                        """
+                sourceSets {
+                    main {
+                        java {
+                            srcDirs = ["src"]
+                        }
+                    }
+                }
+            """
+            )
+
+            createJavaInterfaceFile(CUSTOM_SRC_DIR)
+            createJavaClassFile(CUSTOM_SRC_DIR)
+            createYamlFile(DEFAULT_RESOURCES_DIR)
+        }
+
+        val result = runGradle(projectDir, TASK_NAME)
+
+        assertTaskOutcome(result)
+        assertPatchFileContents(CUSTOM_SRC_DIR)
+    }
+
+    @Test
+    fun `can use non-overlapping custom source set directories`() {
+        gradleProject(projectDir) {
+            rewriteYaml(REWRITE_YAML)
+            buildGradle(
+                REWRITE_BUILD_GRADLE +
+                REWRITE_PLUGIN_ACTIVE_RECIPE +
+                //language=groovy
+                """
+                sourceSets {
+                    main {
+                        java {
+                            srcDirs = ["src"]
+                        }
+                        resources {
+                            srcDirs = ["resources"]
+                        }
+                    }
+                }
+            """
+            )
+
+            createJavaInterfaceFile(CUSTOM_SRC_DIR)
+            createJavaClassFile(CUSTOM_SRC_DIR)
+            createYamlFile(CUSTOM_RESOURCES_DIR)
+        }
+
+        val result = runGradle(projectDir, TASK_NAME)
+
+        assertTaskOutcome(result)
+        assertPatchFileContents(CUSTOM_SRC_DIR)
+    }
+
+    @Test
+    fun `can use overlapping custom source set directories`() {
+        gradleProject(projectDir) {
+            rewriteYaml(REWRITE_YAML)
+            buildGradle(
+                REWRITE_BUILD_GRADLE +
+                REWRITE_PLUGIN_ACTIVE_RECIPE +
+                //language=groovy
+                """
+                sourceSets {
+                    main {
+                        java {
+                            srcDirs = ["src"]
+                        }
+                        resources {
+                            srcDirs = ["src"]
+                            excludes = ["**/*.java"]
+                        }
+                    }
+                }
+            """
+            )
+
+            createJavaInterfaceFile(CUSTOM_SRC_DIR)
+            createJavaClassFile(CUSTOM_SRC_DIR)
+            createYamlFile(CUSTOM_SRC_DIR)
+        }
+
+        val result = runGradle(projectDir, TASK_NAME)
+
+        assertTaskOutcome(result)
+        assertPatchFileContents(CUSTOM_SRC_DIR)
+    }
+
+    @Test
+    fun `can add custom source set directories to default directories`() {
+        gradleProject(projectDir) {
+            rewriteYaml(REWRITE_YAML)
+            buildGradle(
+                REWRITE_BUILD_GRADLE +
+                REWRITE_PLUGIN_ACTIVE_RECIPE +
+                //language=groovy
+                """
+                sourceSets {
+                    main {
+                        java {
+                            srcDir "src"
+                        }
+                        resources {
+                            srcDir "src"
+                            excludes = ["**/*.java"]
+                        }
+                    }
+                }
+            """
+            )
+
+            createJavaInterfaceFile(CUSTOM_SRC_DIR)
+            createJavaClassFile(CUSTOM_SRC_DIR)
+            createYamlFile(CUSTOM_SRC_DIR)
+        }
+
+        val result = runGradle(projectDir, TASK_NAME)
+
+        assertTaskOutcome(result)
+        assertPatchFileContents(CUSTOM_SRC_DIR)
+    }
+
+    private fun createJavaInterfaceFile(sourceDir: String) {
+        createJavaFile(projectDir, sourceDir, "HelloWorld.java", HELLO_WORLD_JAVA_INTERFACE)
+    }
+
+    private fun createJavaClassFile(sourceDir: String) {
+        createJavaFile(projectDir, sourceDir, "HelloWorldImpl.java", HELLO_WORLD_JAVA_CLASS)
+    }
+
+    private fun createJavaFile(projectDir: File, sourceDir: String, fileName: String, content: String) {
+        val dir = File(projectDir, sourceDir)
+        dir.mkdirs()
+        val packageDir = File(dir, "org/openrewrite/before")
+        packageDir.mkdirs()
+        File(packageDir, fileName).writeText(content)
+    }
+
+    private fun createYamlFile(sourceDir: String) {
+        val dir = File(projectDir, sourceDir)
+        dir.mkdirs()
+        File(dir, "foo.yml").writeText("foo: test")
+    }
+
+    private fun assertTaskOutcome(result: BuildResult) {
+        val rewriteDryRunResult = result.task(":${TASK_NAME}")!!
+        assertThat(rewriteDryRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    private fun assertPatchFileContents(sourceDir: String) {
+        val patchFile = File(projectDir, "build/reports/rewrite/rewrite.patch")
+        assertThat(patchFile.exists()).isTrue
+        assertThat(patchFile.readText()).contains(
+            "rename from ${sourceDir}/org/openrewrite/before/HelloWorld.java",
+            "rename to ${sourceDir}/org/openrewrite/after/HelloWorld.java",
+            "rename from ${sourceDir}/org/openrewrite/before/HelloWorldImpl.java",
+            "rename to ${sourceDir}/org/openrewrite/after/HelloWorldImpl.java"
+        )
+    }
+}

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
@@ -16,52 +16,16 @@
 package org.openrewrite.gradle
 
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
 import java.io.File
-import java.lang.management.ManagementFactory
 
-val gradleVersion: String? = System.getProperty("org.openrewrite.test.gradleVersion")
-
-interface RewritePluginTest {
+interface RewritePluginTest: GradleRunnerTest {
 
     fun taskName(): String
-
-    fun runGradle(testDir: File, vararg args: String): BuildResult {
-        return GradleRunner.create()
-            .withDebug(ManagementFactory.getRuntimeMXBean().inputArguments.toString().indexOf("-agentlib:jdwp") > 0)
-            .withProjectDir(testDir)
-            .apply {
-                if (gradleVersion != null) {
-                    withGradleVersion(gradleVersion)
-                }
-            }
-            .withArguments(*args, "--info", "--stacktrace")
-            .withPluginClasspath()
-            .forwardOutput()
-            .build()
-    }
-
-    fun lessThanGradle6_1(): Boolean {
-        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
-        return currentVersion < GradleVersion.version("6.1")
-    }
-
-    fun lessThanGradle6_8(): Boolean {
-        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
-        return currentVersion < GradleVersion.version("6.8")
-    }
-
-    fun lessThanGradle7_4(): Boolean {
-        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
-        return currentVersion < GradleVersion.version("7.4")
-    }
 
     // The configuration cache works on Gradle 6.6+, but rewrite-gradle-plugin uses notCompatibleWithConfigurationCache,
     // which is only available on Gradle 7.4+.
@@ -91,12 +55,5 @@ interface RewritePluginTest {
         val result = runGradle(projectDir, taskName(), "--configuration-cache")
         val taskResult = result.task(":${taskName()}")!!
         assertThat(taskResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
-    }
-
-    fun isAgp3CompatibleGradleVersion(): Boolean {
-        val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
-        return System.getenv("ANDROID_HOME") != null &&
-                currentVersion >= GradleVersion.version("5.0") &&
-                currentVersion < GradleVersion.version("8.0")
     }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
@@ -1,0 +1,24 @@
+package org.openrewrite.gradle.fixtures
+
+class GradleFixtures {
+    companion object {
+        //language=groovy
+        const val REPOSITORIES = """
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven {
+                    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                }
+            }
+        """
+
+        //language=groovy
+        const val REWRITE_BUILD_GRADLE = """
+            plugins {
+                id("java")
+                id("org.openrewrite.rewrite")
+            }
+        """ + REPOSITORIES
+    }
+}

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle.fixtures
 
 class GradleFixtures {

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
@@ -7,7 +7,7 @@ class JavaFixtures {
             package org.openrewrite.before;
 
             public interface HelloWorld {
-                void sayGoodbye();
+                void sayHello();
             }
         """.trimIndent()
 
@@ -17,8 +17,29 @@ class JavaFixtures {
 
             public class HelloWorldImpl implements HelloWorld {
                 @Override
-                public void sayGoodbye() {
+                public void sayHello() {
                     System.out.println("Hello world");
+                }
+            }
+        """.trimIndent()
+
+        //language=java
+        val GOODBYE_WORLD_JAVA_INTERFACE = """
+            package org.openrewrite.before;
+
+            public interface GoodbyeWorld {
+                void sayGoodbye();
+            }
+        """.trimIndent()
+
+        //language=java
+        val GOODBYE_WORLD_JAVA_CLASS = """
+            package org.openrewrite.before;
+
+            public class GoodbyeWorldImpl implements GoodbyeWorld {
+                @Override
+                public void sayGoodbye() {
+                    System.out.println("Goodbye world");
                 }
             }
         """.trimIndent()

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle.fixtures
 
 class JavaFixtures {

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/JavaFixtures.kt
@@ -1,0 +1,26 @@
+package org.openrewrite.gradle.fixtures
+
+class JavaFixtures {
+    companion object {
+        //language=java
+        val HELLO_WORLD_JAVA_INTERFACE = """
+            package org.openrewrite.before;
+
+            public interface HelloWorld {
+                void sayGoodbye();
+            }
+        """.trimIndent()
+
+        //language=java
+        val HELLO_WORLD_JAVA_CLASS = """
+            package org.openrewrite.before;
+
+            public class HelloWorldImpl implements HelloWorld {
+                @Override
+                public void sayGoodbye() {
+                    System.out.println("Hello world");
+                }
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## What's changed?

Just added test cases.

## What's your motivation?

Verify that the handling of Java source files in custom source sets works as expected.

## Any additional context

I am working on a project that seems to have issue with resolving types in the LST when running a recipe. I suspected that it has something to do with definition of custom Gradle source sets, however, all my tests pass.
