### PR TITLE
Initial proposal for license acceptations

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     "rewriteDependencies"("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2")
     "rewriteDependencies"("com.google.guava:guava:latest.release")
     implementation(platform("org.openrewrite:rewrite-bom:$latest"))
+    implementation("org.openrewrite.recipe:rewrite-all:latest.integration")
     compileOnly("com.android.tools.build:gradle:7.0.4")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:latest.release")
     compileOnly("com.google.guava:guava:latest.release")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -117,7 +117,6 @@ dependencies {
     "rewriteDependencies"("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2")
     "rewriteDependencies"("com.google.guava:guava:latest.release")
     implementation(platform("org.openrewrite:rewrite-bom:$latest"))
-    implementation("org.openrewrite.recipe:rewrite-all:latest.integration")
     compileOnly("com.android.tools.build:gradle:7.0.4")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:latest.release")
     compileOnly("com.google.guava:guava:latest.release")

--- a/plugin/src/main/java/org/openrewrite/gradle/LicenseNotAcceptedException.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/LicenseNotAcceptedException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.openrewrite.config.License;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * Goal is that this class moves to rewrite-core as both gradle and Maven plugin can reuse this behaviour.
+ */
+public class LicenseNotAcceptedException extends RuntimeException {
+    protected final Collection<License> unacceptedLicenses;
+
+    public LicenseNotAcceptedException(Collection<License> unacceptedLicenses) {
+        super(buildMessage(unacceptedLicenses));
+        this.unacceptedLicenses = unacceptedLicenses;
+    }
+
+    public Collection<License> getUnacceptedLicenses() {
+        return Collections.unmodifiableCollection(unacceptedLicenses);
+    }
+
+    private static String buildMessage(Collection<License> unacceptedLicenses) {
+        StringBuilder sb = new StringBuilder("Unaccepted licenses detected on the classpath:");
+        for (License unacceptedLicense : unacceptedLicenses) {
+            sb.append("\n  - ").append(unacceptedLicense.getName());
+            if (unacceptedLicense.getUrl() != null) {
+                sb.append("(").append(unacceptedLicense.getUrl()).append(")");
+            }
+        }
+        sb.append("\nEither add command line arguments \"")
+                .append(unacceptedLicenses.stream().map(License::getName).map(LicenseVerifier::asOption).map(option -> "-Drewrite.acceptedLicense." + option.replaceAll(" ", "_")).collect(Collectors.joining(" ")))
+                .append("\" to accept licenses or look at plugin specific solutions.\n")
+                .append("This only needs to be done once. Previously accepted licenses can be revoked again by removing the corresponding lines from ")
+                .append(System.getProperty("user.home"))
+                .append("/.rewrite/licenses.properties");
+
+        return sb.toString();
+    }
+}

--- a/plugin/src/main/java/org/openrewrite/gradle/LicenseVerifier.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/LicenseVerifier.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.License;
+import org.openrewrite.internal.StringUtils;
+
+import java.io.*;
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Goal is that this class moves to rewrite-core as both gradle and Maven plugin can reuse this behaviour.
+ * This allows us to only have 1 test for validation of the licenses per plugin and we can thoroughly test only these 2 public  methods.
+ * It still is easily bypassable -> the goal was not to make it unhackable but to have these that want to play nice kept in the loop of some license change.
+ */
+public class LicenseVerifier {
+
+    private static final String APACHE_LICENSE = "Apache License Version 2.0";
+    private static final String MSAL_LICENSE = "Moderne Source Available License";
+    private static final String MSAL_LICENSE_SHORT = "MSAL";
+    private static final String MSAL_LICENSE_LOWERCASE = "moderne source available license";
+    private static final String MPL_LICENSE = "Moderne Proprietary License";
+    private static final String MPL_LICENSE_SHORT = "MPL";
+    private static final String MPL_LICENSE_LOWERCASE = "moderne proprietary license";
+
+    private static final String LICENSES_PATH = System.getProperty("user.home") + "/.rewrite/licenses.properties";
+
+    private final Map<String, LicenseAcceptation> acceptedLicenses = new HashMap<>();
+    private final Map<String, License> requiredLicenses;
+
+    //For Maven
+    public static void verifyAllLicensesAccepted(Environment environment) {
+        verifyAllLicensesAccepted(environment, Collections.emptyList());
+    }
+
+    //For Gradle
+    public static void verifyAllLicensesAccepted(Environment environment, List<String> toolAcceptedLicense) {
+        new LicenseVerifier(environment.listLicenses(), toolAcceptedLicense).verify();
+    }
+
+    private LicenseVerifier(Set<License> requiredLicenses, List<String> additionallyAcceptedLicenses) {
+        File userHomeRewriteLicenseConfig = new File(LICENSES_PATH);
+        if (userHomeRewriteLicenseConfig.exists()) {
+            try (BufferedReader licenses = new BufferedReader(new FileReader(userHomeRewriteLicenseConfig))) {
+                licenses.lines().filter(Objects::nonNull).filter(s -> !s.trim().isEmpty()).map(LicenseAcceptation::ofProperty).forEach(license -> acceptedLicenses.put(license.getLicense(), license));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        this.requiredLicenses = requiredLicenses.stream()
+                .filter(license -> !isAccepted(license.getName()))
+                .collect(Collectors.toMap(License::getName, Function.identity()));
+
+        acceptSystemPropertyLicenses();
+        if (!this.requiredLicenses.isEmpty()) {
+            additionallyAcceptedLicenses.forEach(this::acceptLicenseIfRequired);
+        }
+    }
+
+    private void acceptLicenseIfRequired(String license) {
+        String licenseName = asLicenseName(license);
+        License requiredLicense = requiredLicenses.values().stream().filter(name -> name.getName().equalsIgnoreCase(licenseName)).findFirst().orElse(null);
+        if (requiredLicense == null) {
+            return;
+        }
+        acceptedLicenses.put(requiredLicense.getName(), new LicenseAcceptation(requiredLicense.getName(), Instant.now())); //renew acceptation timestamp
+        requiredLicenses.remove(requiredLicense.getName());
+    }
+
+    private void verify() {
+        if (!acceptedLicenses.isEmpty()) {
+            File userHomeRewriteLicenseConfig = new File(LICENSES_PATH);
+            userHomeRewriteLicenseConfig.getParentFile().mkdirs();
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(userHomeRewriteLicenseConfig))) {
+                for (LicenseAcceptation license : acceptedLicenses.values()) {
+                    writer.write(license.getLicense() + "=" + license.getAcceptedAt().getEpochSecond());
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        if (!requiredLicenses.isEmpty()) {
+            throw new LicenseNotAcceptedException(requiredLicenses.values());
+        }
+    }
+
+    private boolean isAccepted(String license) {
+        String licenseName = asLicenseName(license);
+        if (APACHE_LICENSE.equals(licenseName)) {
+            return true;
+        }
+        return acceptedLicenses.containsKey(licenseName);
+    }
+
+    private void acceptSystemPropertyLicenses() {
+        if (!requiredLicenses.isEmpty()) {
+            for (Object systemProp : System.getProperties().keySet()) {
+                if (systemProp instanceof String) {
+                    String key = (String) systemProp;
+                    if (key.toLowerCase().startsWith("rewrite.acceptedlicense.")) {
+                        String license = System.getProperty(key);
+                        if (license != null) {
+                            acceptLicenseIfRequired(key.substring("rewrite.acceptedlicense.".length()).replaceAll("_", " "));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public static class LicenseAcceptation {
+        private final String license;
+        private final Instant acceptedAt;
+
+        private LicenseAcceptation(String license, Instant acceptedAt) {
+            this.license = asLicenseName(license);
+            this.acceptedAt = acceptedAt;
+        }
+
+        private static LicenseAcceptation ofProperty(String property) {
+            int splitOn = property.lastIndexOf("=");
+            if (splitOn == -1) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(does not contain a '=')");
+            }
+            String licenseName = property.substring(0, splitOn);
+            String acceptedAt = property.substring(splitOn + 1);
+            if (licenseName.trim().isEmpty()) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(license name empty)");
+            }
+            if (acceptedAt.trim().isEmpty() || !StringUtils.isNumeric(acceptedAt)) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(not an epoch-second/numeric value)");
+            }
+
+            return new LicenseAcceptation(licenseName, Instant.ofEpochSecond(Long.parseLong(acceptedAt)));
+        }
+
+        public Instant getAcceptedAt() {
+            return acceptedAt;
+        }
+
+        public String getLicense() {
+            return license;
+        }
+    }
+
+    public static String asLicenseName(String license) {
+        switch (license.toUpperCase()) {
+            case MSAL_LICENSE_SHORT: return MSAL_LICENSE;
+            case MPL_LICENSE_SHORT: return MPL_LICENSE;
+            default: return license;
+        }
+    }
+
+    public static String asOption(String license) {
+        switch (license.toLowerCase()) {
+            case MSAL_LICENSE_LOWERCASE: return MSAL_LICENSE_SHORT;
+            case MPL_LICENSE_LOWERCASE: return MPL_LICENSE_SHORT;
+            default: return license;
+        }
+    }
+}

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyMap;
 @SuppressWarnings("unused")
 public class RewriteExtension {
 
+    private final List<String> acceptedLicenses = new ArrayList<>();
     private final List<String> activeRecipes = new ArrayList<>();
     private final List<String> activeStyles = new ArrayList<>();
     private boolean configFileSetDeliberately;
@@ -129,6 +130,19 @@ public class RewriteExtension {
         return configFile;
     }
 
+    public void acceptedLicenses(String... acceptedLicenses) {
+        this.acceptedLicenses.addAll(asList(acceptedLicenses));
+    }
+
+    public void setAcceptedLicenses(List<String> acceptedLicenses) {
+        this.acceptedLicenses.clear();
+        this.acceptedLicenses.addAll(acceptedLicenses);
+    }
+
+    public List<String> getAcceptedLicenses() {
+        return acceptedLicenses;
+    }
+
     public void activeRecipe(String... recipes) {
         activeRecipes.addAll(asList(recipes));
     }
@@ -140,6 +154,10 @@ public class RewriteExtension {
     public void setActiveRecipes(List<String> activeRecipes) {
         this.activeRecipes.clear();
         this.activeRecipes.addAll(activeRecipes);
+    }
+
+    public List<String> getActiveRecipes() {
+        return activeRecipes;
     }
 
     public void activeStyle(String... styles) {
@@ -157,10 +175,6 @@ public class RewriteExtension {
 
     public List<String> getActiveStyles() {
         return activeStyles;
-    }
-
-    public List<String> getActiveRecipes() {
-        return activeRecipes;
     }
 
     public Properties getVersionProps() {

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -333,7 +333,7 @@ public class DefaultProjectParser implements GradleProjectParser {
         }
     }
 
-    public void dryRun(Path reportPath, ResultsContainer results) {
+    private void dryRun(Path reportPath, ResultsContainer results) {
         try {
             RuntimeException firstException = results.getFirstException();
             if (firstException != null) {
@@ -419,7 +419,7 @@ public class DefaultProjectParser implements GradleProjectParser {
         run(listResults(ctx), ctx);
     }
 
-    public void run(ResultsContainer results, ExecutionContext ctx) {
+    private void run(ResultsContainer results, ExecutionContext ctx) {
         try {
             if (results.isNotEmpty()) {
                 Duration estimateTimeSaved = Duration.ZERO;

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -42,10 +42,7 @@ import org.openrewrite.binary.Binary;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.config.YamlResourceLoader;
-import org.openrewrite.gradle.GradleParser;
-import org.openrewrite.gradle.GradleProjectParser;
-import org.openrewrite.gradle.RewriteExtension;
-import org.openrewrite.gradle.SanitizedMarkerPrinter;
+import org.openrewrite.gradle.*;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.marker.GradleProjectBuilder;
 import org.openrewrite.gradle.marker.GradleSettings;
@@ -294,6 +291,7 @@ public class DefaultProjectParser implements GradleProjectParser {
 
     @Override
     public void dryRun(Path reportPath, boolean dumpGcActivity, Consumer<Throwable> onError) {
+        LicenseVerifier.verifyAllLicensesAccepted(environment(), extension.getAcceptedLicenses());
         ParsingExecutionContextView ctx = view(new InMemoryExecutionContext(onError));
         if (dumpGcActivity) {
             SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -416,6 +414,7 @@ public class DefaultProjectParser implements GradleProjectParser {
 
     @Override
     public void run(Consumer<Throwable> onError) {
+        LicenseVerifier.verifyAllLicensesAccepted(environment(), extension.getAcceptedLicenses());
         ExecutionContext ctx = new InMemoryExecutionContext(onError);
         run(listResults(ctx), ctx);
     }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
@@ -40,6 +40,21 @@ interface GradleRunnerTest {
             .build()
     }
 
+    fun runFailedGradle(testDir: File, vararg args: String): BuildResult {
+        return GradleRunner.create()
+            .withDebug(ManagementFactory.getRuntimeMXBean().inputArguments.toString().indexOf("-agentlib:jdwp") > 0)
+            .withProjectDir(testDir)
+            .apply {
+                if (gradleVersion != null) {
+                    withGradleVersion(gradleVersion)
+                }
+            }
+            .withArguments(*args)
+            .withPluginClasspath()
+            .forwardOutput()
+            .buildAndFail()
+    }
+
     fun lessThanGradle6_1(): Boolean {
         val currentVersion = if (gradleVersion == null) GradleVersion.current() else GradleVersion.version(gradleVersion)
         return currentVersion < GradleVersion.version("6.1")


### PR DESCRIPTION
## What's changed?
A first swing at doing license validations. 
NOTE: 
- LicenseNotAcceptedException
- LicenseVerifier

Would both go to rewrite-core before merging this, I will also try to add some way of storing artifacts that have this required license so that people can also remove the recipe jar dependency if they do not need that particular one as now it is rather hard to find which dependency needs the license.

Also I am seeing failing unit tests locally that have little to do with my changes: 
- 3 problems were found storing the configuration cache.
    - Gradle runtime: support for using a Java agent with TestKit builds is not yet implemented with the configuration cache. See https://docs.gradle.org/8.14.1/userguide/configuration_cache.html#config_cache:not_yet_implemented:testkit_build_with_java_agent
    - Task `:rewriteRun` of type `org.openrewrite.gradle.RewriteRunTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14.1/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
    - Task `:rewriteRun` of type `org.openrewrite.gradle.RewriteRunTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/8.14.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
