### PR TITLE
Exclude node audit, as it's unused here and failing for Kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,11 @@ allprojects {
         failBuildOnCVSS = 9.0F
         suppressionFile = "suppressions.xml"
         nvd.apiKey = System.getenv("NVD_API_KEY")
+        analyzers {
+            nodeAudit {
+                enabled = false
+            }
+        }
     }
 
     dependencies{


### PR DESCRIPTION
In response to seeing

```
Analyzing using Yarn Classic audit
An error occurred while analyzing '/tmp/dctemp5b18dd57-4b8d-4941-900d-9c0bab39739a/check4410636896288089178tmp/11/org/jetbrains/kotlin/gradle/targets/js/yarn/yarn.lock' (Yarn Audit Analyzer): Failed to read results from the NPM Audit API (YarnAuditAnalyzer); the analyzer is being disabled and may result in false negatives.
Suppression Rule had zero matches: SuppressionRule{packageUrl=PropertyType{value=^pkg:maven/com\.google\.guava/guava@.*$, regex=true, caseSensitive=false},vulnerabilityName={PropertyType{value=CVE-2023-2976, regex=false, caseSensitive=false},PropertyType{value=CVE-2020-8908, regex=false, caseSensitive=false},}}
```