### PR TITLE
Don't close `Git` in `DefaultProjectParser#getRepository()`

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -160,7 +160,10 @@ public class DefaultProjectParser implements GradleProjectParser {
     }
 
     static @Nullable Repository getRepository(Path rootDir) {
-        try (Git git = Git.open(rootDir.toFile())) {
+        try {
+            // Repository is closed in `shutdownRewrite()`
+            //noinspection resource
+            Git git = Git.open(rootDir.toFile());
             return git.getRepository();
         } catch (IOException e) {
             // no git


### PR DESCRIPTION
Closing `Git` also closes the created `Repository`. While this doesn't appear to cause any problems, it seems better to keep it open. The alternative would be to remove the `Repository#close()` call from `shutdownRewrite()`.

I believe this is what causes the following type of message to get logged in builds after each project:

close() called when useCnt is already zero for Repository[/var/moderne/partition-at-2025-09-22-04-54/getsentry/sentry-java/.git]
