### PR TITLE
Remove unused methods from `AbstractRewriteTask` and `RewriteClassLoader`

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -20,12 +20,10 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.UntrackedTask;
 
 import javax.inject.Inject;
 import java.nio.file.Path;
 
-@UntrackedTask(because = "Rewrite tasks must not run in parallel due to shared classloader")
 public class RewriteDryRunTask extends AbstractRewriteTask {
 
     private static final Logger logger = Logging.getLogger(RewriteDryRunTask.class);

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
@@ -18,11 +18,9 @@ package org.openrewrite.gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.UntrackedTask;
 
 import javax.inject.Inject;
 
-@UntrackedTask(because = "Rewrite tasks must not run in parallel due to shared classloader")
 public class RewriteRunTask extends AbstractRewriteTask {
 
     private static final Logger logger = Logging.getLogger(RewriteRunTask.class);


### PR DESCRIPTION
## What's your motivation?
We've had reports in #212 that parallel and partial runs throw an exception when trying to load duplicate classes. 

## Have you considered any alternatives or workarounds?
0. The [docs on untracked](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.tasks/-untracked-task/index.html) are not a 100% clear on if this avoids all parallel runs. 
1. There's an alternative in `getOutputs().upToDateWhen(task -> false);` which we could set in AbstractRewriteTask instead.
2. With more effort we might be able to tweak `DelegatingProjectParser` to support parallel classloaders each with their own `GradleProjectParser`, but the impact of that on reliable recipe runs is hard to judge at this moment, but likely leads to fragile runs.
3. We could try to avoid the duplicate class loading by adding locks on `org.openrewrite.gradle.RewriteClassLoader#loadClass`, but it's not clear whether that's a viable option here, and again could lead to fragile recipe runs.

## Any additional context
- Accidentally pushed to main: https://github.com/openrewrite/rewrite-gradle-plugin/commit/89424528fe0a99ce0ef5ca006f25f5ab55225b52, which then closes https://github.com/openrewrite/rewrite-gradle-plugin/issues/212