### PR TITLE
Add Git object information marker to all source files

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1536,7 +1536,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                     treeWalk.setFilter(PathFilter.create(PathUtils.separatorsToUnix(s.getSourcePath().toString())));
 
                     if (treeWalk.next()) {
-                        return s.withMarkers(s.getMarkers().add(new GitTreeEntry(randomId(), treeWalk.getObjectId(0).name(), new org.openrewrite.marker.FileMode(treeWalk.getRawMode(0)))));
+                        return s.withMarkers(s.getMarkers().add(new GitTreeEntry(randomId(), treeWalk.getObjectId(0).name(), treeWalk.getRawMode(0))));
                     }
                     return s;
                 }


### PR DESCRIPTION
## What's changed?
- Utilize `GitObject` marker from https://github.com/openrewrite/rewrite/pull/6347.

## What's your motivation?
Enable tracking of the Git object id, so that we can still generate Git patches when the old content is not available, such as with `Quark`.

## Anything in particular you'd like reviewers to focus on?
N/A

## Anyone you would like to review specifically?
Anybody

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
- Depends on https://github.com/openrewrite/rewrite/pull/6347

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
