### PR TITLE
Fix isExcluded gitignore handling using shared GitIgnore utility

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -91,6 +91,9 @@ val rewriteDependencies = configurations.create("rewriteDependencies")
 configurations.named("compileOnly").configure {
     extendsFrom(rewriteDependencies)
 }
+configurations.named("testRuntimeOnly").configure {
+    extendsFrom(rewriteDependencies)
+}
 
 dependencies {
     "rewriteDependencies"(platform("org.openrewrite:rewrite-bom:$latest"))

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -52,6 +52,7 @@ import org.openrewrite.gradle.marker.GradleProjectBuilder;
 import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.gradle.marker.GradleSettingsBuilder;
 import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.internal.GitIgnore;
 import org.openrewrite.internal.InMemoryLargeSourceSet;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -63,16 +64,12 @@ import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.style.CheckstyleConfigLoader;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.jgit.api.Git;
-import org.openrewrite.jgit.lib.FileMode;
 import org.openrewrite.jgit.lib.ObjectId;
 import org.openrewrite.jgit.lib.Repository;
 import org.openrewrite.jgit.revwalk.RevCommit;
 import org.openrewrite.jgit.revwalk.RevWalk;
-import org.openrewrite.jgit.treewalk.FileTreeIterator;
 import org.openrewrite.jgit.treewalk.TreeWalk;
-import org.openrewrite.jgit.treewalk.WorkingTreeIterator;
 import org.openrewrite.jgit.treewalk.filter.PathFilter;
-import org.openrewrite.jgit.treewalk.filter.PathFilterGroup;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.*;
@@ -1381,36 +1378,19 @@ public class DefaultProjectParser implements GradleProjectParser {
                 return true;
             }
         }
-        // PathMather will not evaluate the path "build.gradle" to be matched by the pattern "**/build.gradle"
+        // PathMatcher will not evaluate the path "build.gradle" to be matched by the pattern "**/build.gradle"
         // This is counter-intuitive for most users and would otherwise require separate exclusions for files at the root and files in subdirectories
         if (!path.isAbsolute() && !path.startsWith(File.separator)) {
-            return isExcluded(repository, exclusions, Paths.get("/" + path));
+            Path prefixed = Paths.get("/" + path);
+            for (PathMatcher excluded : exclusions) {
+                if (excluded.matches(prefixed)) {
+                    return true;
+                }
+            }
         }
 
         if (repository != null) {
-            String repoRelativePath = PathUtils.separatorsToUnix(path.toString());
-            if (repoRelativePath.isEmpty() || "/".equals(repoRelativePath)) {
-                return false;
-            }
-
-            try (TreeWalk walk = new TreeWalk(repository)) {
-                walk.addTree(new FileTreeIterator(repository));
-                walk.setFilter(PathFilterGroup.createFromStrings(repoRelativePath));
-                while (walk.next()) {
-                    WorkingTreeIterator workingTreeIterator = walk.getTree(0, WorkingTreeIterator.class);
-                    if (walk.getPathString().equals(repoRelativePath)) {
-                        return workingTreeIterator.isEntryIgnored();
-                    }
-                    if (workingTreeIterator.getEntryFileMode().equals(FileMode.TREE)) {
-                        if (workingTreeIterator.isEntryIgnored()) {
-                            return true;
-                        }
-                        walk.enterSubtree();
-                    }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            return GitIgnore.isIgnoredAndUntracked(repository, path);
         }
         return false;
     }

--- a/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
@@ -21,9 +21,12 @@ import org.openrewrite.jgit.api.Git;
 import org.openrewrite.jgit.lib.Repository;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,6 +111,61 @@ class DefaultProjectParserIsExcludedTest {
                     .as("tracked file in gitignored directory should NOT be excluded")
                     .isFalse();
         }
+    }
+
+    @Test
+    void exclusionMatcherMatchesDirectly() {
+        Collection<PathMatcher> matchers = Collections.singletonList(
+                FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
+
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("config/secret.properties")))
+                .as("path matching exclusion pattern should be excluded")
+                .isTrue();
+    }
+
+    @Test
+    void exclusionMatcherDoesNotMatchUnrelatedPath() {
+        Collection<PathMatcher> matchers = Collections.singletonList(
+                FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
+
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("config/application.properties")))
+                .as("path not matching exclusion pattern should not be excluded")
+                .isFalse();
+    }
+
+    @Test
+    void exclusionMatcherMatchesRootFileViaPrefixedSlash() {
+        // PathMatcher won't match "build.gradle" against "**/build.gradle" without a leading slash;
+        // isExcluded handles this by re-checking with a "/" prefix for relative paths
+        Collection<PathMatcher> matchers = Collections.singletonList(
+                FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
+
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("build.gradle")))
+                .as("root-level file should match **/build.gradle via leading-slash prefixing")
+                .isTrue();
+    }
+
+    @Test
+    void exclusionMatcherMatchesRootFileWithLeadingSlash() {
+        // When the path already has a leading slash, it should match directly
+        // without needing the prefixing logic
+        Collection<PathMatcher> matchers = Collections.singletonList(
+                FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
+
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("/build.gradle")))
+                .as("root-level file with leading slash should match **/build.gradle directly")
+                .isTrue();
+    }
+
+    @Test
+    void exclusionMatcherMatchesSubdirFileWithoutPrefixing() {
+        // A file in a subdirectory should match directly without needing the "/" prefix path
+        Collection<PathMatcher> matchers = Collections.singletonList(
+                FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
+
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("module/build.gradle")))
+                .as("subdirectory file should match **/build.gradle directly")
+                .isTrue();
     }
 
     private static void writeFile(Path path, String content) throws Exception {

--- a/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.isolated;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.jgit.api.Git;
+import org.openrewrite.jgit.lib.Repository;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the gitignore handling in {@link DefaultProjectParser#isExcluded}.
+ * <p>
+ * The original implementation had a bug where the recursive call that prepends
+ * "/" for PathMatcher compatibility caused the JGit TreeWalk path comparison
+ * to never match, making the gitignore check dead code. These tests verify
+ * that gitignore exclusions actually take effect for relative paths.
+ */
+class DefaultProjectParserIsExcludedTest {
+
+    @Test
+    void untrackedGitIgnoredFileIsExcluded(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve(".gitignore"), "generated.txt\n");
+            writeFile(tempDir.resolve("generated.txt"), "untracked content");
+
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("initial").call();
+
+            assertThat(DefaultProjectParser.isExcluded(repo, Collections.emptyList(), Paths.get("generated.txt")))
+                    .as("untracked gitignored file should be excluded")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void trackedGitIgnoredFileIsNotExcluded(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve("tracked-ignored.txt"), "content");
+            git.add().addFilepattern("tracked-ignored.txt").call();
+            git.commit().setMessage("initial").call();
+
+            writeFile(tempDir.resolve(".gitignore"), "tracked-ignored.txt\n");
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("add gitignore").call();
+
+            assertThat(DefaultProjectParser.isExcluded(repo, Collections.emptyList(), Paths.get("tracked-ignored.txt")))
+                    .as("tracked gitignored file should NOT be excluded")
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void untrackedFileInGitIgnoredDirectoryIsExcluded(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve(".gitignore"), "build/\n");
+            writeFile(tempDir.resolve("build/output.txt"), "untracked content");
+
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("initial").call();
+
+            assertThat(DefaultProjectParser.isExcluded(repo, Collections.emptyList(), Paths.get("build/output.txt")))
+                    .as("untracked file in gitignored directory should be excluded")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void trackedFileInGitIgnoredDirectoryIsNotExcluded(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve("build/output.txt"), "tracked content");
+            git.add().addFilepattern("build/output.txt").call();
+            git.commit().setMessage("initial").call();
+
+            writeFile(tempDir.resolve(".gitignore"), "build/\n");
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("add gitignore").call();
+
+            assertThat(DefaultProjectParser.isExcluded(repo, Collections.emptyList(), Paths.get("build/output.txt")))
+                    .as("tracked file in gitignored directory should NOT be excluded")
+                    .isFalse();
+        }
+    }
+
+    private static void writeFile(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Fixes two bugs in `isExcluded`:

1. A recursive call prepending `/` for PathMatcher compatibility broke the JGit TreeWalk path comparison (JGit paths never have a leading slash), making the gitignore check dead code.
2. Only `isEntryIgnored()` was checked without consulting the git index, so tracked files matching `.gitignore` would have been incorrectly excluded if the path bug were fixed.

Replaces the inline JGit implementation with the shared `GitIgnore.isIgnoredAndUntracked()` utility from rewrite-core (openrewrite/rewrite#7215).

Depends on openrewrite/rewrite#7215.