### PR TITLE
Exclude generated sources in build directory from parsing

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
@@ -136,8 +136,6 @@ class AndroidProjectParser {
                     alreadyParsed.addAll(javaPaths);
                     Stream<SourceFile> parsedJavaFiles = parseJavaFiles(javaPaths,
                             ctx,
-                            buildDir,
-                            exclusions,
                             javaSourceCharset,
                             javaVersion,
                             dependencyPaths,
@@ -152,8 +150,6 @@ class AndroidProjectParser {
                     alreadyParsed.addAll(kotlinPaths);
                     Stream<SourceFile> parsedKotlinFiles = parseKotlinFiles(kotlinPaths,
                             ctx,
-                            buildDir,
-                            exclusions,
                             javaVersion,
                             dependencyPaths,
                             javaTypeCache);
@@ -183,8 +179,11 @@ class AndroidProjectParser {
                 }
 
                 JavaSourceSet sourceSetProvenance = JavaSourceSet.build(sourceSetName, dependencyPaths);
-                sourceFileStream = sourceFileStream.concat(sourceSetSourceFiles.map(DefaultProjectParser.addProvenance(
-                                sourceSetProvenance)),
+                sourceFileStream = sourceFileStream.concat(
+                        sourceSetSourceFiles
+                                .filter(cu -> !DefaultProjectParser.isExcluded(repository, exclusions, cu.getSourcePath()) &&
+                                        !cu.getSourcePath().startsWith(buildDir))
+                                .map(DefaultProjectParser.addProvenance(sourceSetProvenance)),
                         sourceSetSize);
             }
         }
@@ -282,8 +281,6 @@ class AndroidProjectParser {
 
     private Stream<SourceFile> parseJavaFiles(List<Path> javaPaths,
                                               ExecutionContext ctx,
-                                              Path buildDir,
-                                              Collection<PathMatcher> exclusions,
                                               Charset javaSourceCharset,
                                               JavaVersion javaVersion,
                                               Set<Path> dependencyPaths,
@@ -299,19 +296,11 @@ class AndroidProjectParser {
                     view(ctx).setCharset(javaSourceCharset);
                     return jp.parse(javaPaths, baseDir, ctx).onClose(() -> view(ctx).setCharset(null));
                 })
-                .map(cu -> {
-                    if (DefaultProjectParser.isExcluded(repository, exclusions, cu.getSourcePath()) || cu.getSourcePath()
-                            .startsWith(buildDir)) {
-                        return null;
-                    }
-                    return cu;
-                }).filter(Objects::nonNull).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
+                .map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
     }
 
     private Stream<SourceFile> parseKotlinFiles(List<Path> kotlinPaths,
                                                 ExecutionContext ctx,
-                                                Path buildDir,
-                                                Collection<PathMatcher> exclusions,
                                                 JavaVersion javaVersion,
                                                 Set<Path> dependencyPaths,
                                                 JavaTypeCache javaTypeCache) {
@@ -326,12 +315,6 @@ class AndroidProjectParser {
                     view(ctx).setCharset(StandardCharsets.UTF_8); // Kotlin requires UTF-8
                     return kp.parse(kotlinPaths, baseDir, ctx).onClose(() -> view(ctx).setCharset(null));
                 })
-                .map(cu -> {
-                    if (DefaultProjectParser.isExcluded(repository, exclusions, cu.getSourcePath()) || cu.getSourcePath()
-                            .startsWith(buildDir)) {
-                        return null;
-                    }
-                    return cu;
-                }).filter(Objects::nonNull).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
+                .map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
     }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -773,9 +773,12 @@ public class DefaultProjectParser implements GradleProjectParser {
                     .getByName(sourceSet.getCompileJavaTaskName());
             JavaVersion javaVersion = getJavaVersion(javaCompileTask);
 
+            Path absoluteBuildDir = subproject.getLayout().getBuildDirectory()
+                    .get().getAsFile().toPath().toAbsolutePath().normalize();
             List<Path> unparsedSources = sourceSet.getAllSource()
                     .getSourceDirectories()
                     .filter(File::exists)
+                    .filter(dir -> !dir.toPath().toAbsolutePath().normalize().startsWith(absoluteBuildDir))
                     .filter(dir -> !alreadyParsed.contains(dir.toPath()))
                     .getFiles()
                     .stream()
@@ -839,10 +842,8 @@ public class DefaultProjectParser implements GradleProjectParser {
             }
 
             if (subproject.getPlugins().hasPlugin("org.jetbrains.kotlin.jvm")) {
-                String excludedProtosPath = subproject.getProjectDir().getPath() + "/protos/build/generated";
                 List<Path> kotlinPaths = unparsedSources.stream()
                         .filter(it -> it.toString().endsWith(".kt"))
-                        .filter(it -> !it.toString().startsWith(excludedProtosPath))
                         .collect(toList());
 
                 if (!kotlinPaths.isEmpty()) {

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -826,8 +826,6 @@ public class DefaultProjectParser implements GradleProjectParser {
                 Stream<SourceFile> parsedJavaFiles = parseJavaFiles(
                         javaPaths,
                         ctx,
-                        buildDir,
-                        exclusions,
                         getSourceFileEncoding(javaCompileTask.getOptions()),
                         javaVersion,
                         dependencyPaths,
@@ -851,8 +849,6 @@ public class DefaultProjectParser implements GradleProjectParser {
                     Stream<SourceFile> parsedKotlinFiles = parseKotlinFiles(
                             kotlinPaths,
                             ctx,
-                            buildDir,
-                            exclusions,
                             javaVersion,
                             dependencyPaths,
                             javaTypeCache);
@@ -891,12 +887,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                             .flatMap(gp -> {
                                 view(ctx).setCharset(getSourceFileEncoding(groovyCompileTask.getOptions()));
                                 return gp.parse(groovyPaths, baseDir, ctx).onClose(() -> view(ctx).setCharset(null));
-                            }).map(cu -> {
-                        if (isExcluded(repository, exclusions, cu.getSourcePath()) || cu.getSourcePath().startsWith(buildDir)) {
-                            return null;
-                        }
-                        return cu;
-                    }).filter(Objects::nonNull).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
+                            }).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
                     sourceSetSourceFiles = Stream.concat(sourceSetSourceFiles, cus);
                     sourceSetSize += groovyPaths.size();
                     logger.info(
@@ -922,7 +913,10 @@ public class DefaultProjectParser implements GradleProjectParser {
 
             JavaSourceSet sourceSetProvenance = JavaSourceSet.build(sourceSet.getName(), dependencyPaths);
             sourceFileStream = sourceFileStream.concat(
-                    sourceSetSourceFiles.map(addProvenance(sourceSetProvenance)),
+                    sourceSetSourceFiles
+                            .filter(cu -> !isExcluded(repository, exclusions, cu.getSourcePath()) &&
+                                    !cu.getSourcePath().startsWith(buildDir))
+                            .map(addProvenance(sourceSetProvenance)),
                     sourceSetSize);
             // Some source sets get misconfigured to have the same directories as other source sets
             // Prevent files which appear in multiple source sets from being parsed more than once
@@ -953,8 +947,6 @@ public class DefaultProjectParser implements GradleProjectParser {
     private Stream<SourceFile> parseJavaFiles(
             List<Path> javaPaths,
             ExecutionContext ctx,
-            Path buildDir,
-            Collection<PathMatcher> exclusions,
             Charset javaSourceCharset,
             JavaVersion javaVersion,
             Set<Path> dependencyPaths,
@@ -969,18 +961,11 @@ public class DefaultProjectParser implements GradleProjectParser {
                     view(ctx).setCharset(javaSourceCharset);
                     return jp.parse(javaPaths, baseDir, ctx).onClose(() -> view(ctx).setCharset(null));
                 })
-                .map(cu -> {
-                    if (isExcluded(repository, exclusions, cu.getSourcePath()) || cu.getSourcePath().startsWith(buildDir)) {
-                        return null;
-                    }
-                    return cu;
-                }).filter(Objects::nonNull).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
+                .map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
     }
 
     private Stream<SourceFile> parseKotlinFiles(List<Path> kotlinPaths,
                                                 ExecutionContext ctx,
-                                                Path buildDir,
-                                                Collection<PathMatcher> exclusions,
                                                 JavaVersion javaVersion,
                                                 Set<Path> dependencyPaths,
                                                 JavaTypeCache javaTypeCache) {
@@ -994,12 +979,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                     view(ctx).setCharset(StandardCharsets.UTF_8); // Kotlin requires UTF-8
                     return kp.parse(kotlinPaths, baseDir, ctx).onClose(() -> view(ctx).setCharset(null));
                 })
-                .map(cu -> {
-                    if (isExcluded(repository, exclusions, cu.getSourcePath()) || cu.getSourcePath().startsWith(buildDir)) {
-                        return null;
-                    }
-                    return cu;
-                }).filter(Objects::nonNull).map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
+                .map(it -> it.withMarkers(it.getMarkers().add(javaVersion)));
     }
 
     private GradleParser gradleParser() {
@@ -1341,16 +1321,13 @@ public class DefaultProjectParser implements GradleProjectParser {
 
                     Stream<SourceFile> cus = kp.parse(kotlinPaths, baseDir, ctx);
                     alreadyParsed.addAll(kotlinPaths);
-                    cus = cus.map(cu -> {
-                        if (isExcluded(repository, exclusions, cu.getSourcePath()) ||
-                            cu.getSourcePath().startsWith(buildDirPath)) {
-                            return null;
-                        }
-                        return cu;
-                    }).filter(Objects::nonNull);
                     JavaSourceSet sourceSetProvenance = JavaSourceSet.build(sourceSetName, dependencyPaths);
 
-                    sourceFileStream = sourceFileStream.concat(cus.map(addProvenance(sourceSetProvenance)), kotlinPaths.size());
+                    sourceFileStream = sourceFileStream.concat(
+                            cus.filter(cu -> !isExcluded(repository, exclusions, cu.getSourcePath()) &&
+                                    !cu.getSourcePath().startsWith(buildDirPath))
+                                    .map(addProvenance(sourceSetProvenance)),
+                            kotlinPaths.size());
                     logger.info("Scanned {} Kotlin sources in {}/{}", kotlinPaths.size(), subproject.getPath(), kotlinDirectorySet.getName());
                 }
             } catch (Exception e) {


### PR DESCRIPTION
- Fixes #216.

## Summary
- Source directories inside the build directory (e.g. protobuf-generated Kotlin sources) are now filtered out at the directory level before file walking, preventing generated sources from being parsed and appearing in recipe results
- Type information from generated sources remains available via compiled class files already on the classpath
- Removed the hardcoded `/protos/build/generated` exclusion, now covered by the generic build directory filter
- Consolidated duplicated `isExcluded`/`buildDir` filtering from individual parse methods (`parseJavaFiles`, `parseKotlinFiles`, inline Groovy/multiplatform blocks) into a single filter at the stream assembly point, in both `DefaultProjectParser` and `AndroidProjectParser`

## Test plan
- [x] Existing tests pass (`./gradlew :plugin:test`)