### PR TITLE
Mark plugin-created configurations as non-consumable

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -68,6 +68,7 @@ public class RewritePlugin implements Plugin<Project> {
 
         // Rewrite module dependencies put here will be available to all rewrite tasks
         Configuration rewriteConf = project.getConfigurations().maybeCreate("rewrite");
+        rewriteConf.setCanBeConsumed(false);
 
         Provider<Set<File>> resolvedDependenciesProvider = project.provider(() -> getResolvedDependencies(project, extension, rewriteConf));
 

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1302,6 +1302,8 @@ public class DefaultProjectParser implements GradleProjectParser {
                         .invoke(sourceSet);
                 Configuration implementation = subproject.getConfigurations().getByName(implementationName);
                 Configuration rewriteImplementation = subproject.getConfigurations().maybeCreate("rewrite" + implementationName);
+                rewriteImplementation.setCanBeConsumed(false);
+                rewriteImplementation.setCanBeResolved(true);
                 if (!rewriteImplementation.getExtendsFrom().contains(implementation)) {
                     rewriteImplementation.extendsFrom(implementation);
                 }
@@ -1318,6 +1320,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                 String compileName = (String) sourceSet.getClass().getMethod("getCompileOnlyConfigurationName").invoke(sourceSet);
                 Configuration compileOnly = subproject.getConfigurations().getByName(compileName);
                 Configuration rewriteCompileOnly = subproject.getConfigurations().maybeCreate("rewrite" + compileName);
+                rewriteCompileOnly.setCanBeConsumed(false);
                 rewriteCompileOnly.setCanBeResolved(true);
                 rewriteCompileOnly.extendsFrom(compileOnly);
 


### PR DESCRIPTION
- Fixes #239.

Sets `setCanBeConsumed(false)` on the `rewrite`, `rewriteImplementation`, and `rewriteCompileOnly` configurations to eliminate Gradle deprecation warnings about configurations being both consumable and declarable. Also explicitly sets `setCanBeResolved(true)` on `rewriteImplementation` since it is resolved directly. All tests pass including Gradle 4.10 compatibility tests.