### PR TITLE
Add Javadoc to RewriteExtension and sync test to prevent drift

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -19,7 +19,7 @@ gradlePlugin {
         create("rewrite") {
             id = "org.openrewrite.rewrite"
             displayName = "Rewrite"
-            description = "Automatically eliminate technical debt"
+            description = "Automatically eliminate technical debt. Apply OpenRewrite recipes to refactor, migrate, and fix source code across Java, Kotlin, Gradle, XML, YAML, properties, and more."
             implementationClass = "org.openrewrite.gradle.RewritePlugin"
             tags.set(listOf("rewrite", "refactoring", "remediation", "security", "migration", "java", "checkstyle"))
         }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -19,7 +19,10 @@ gradlePlugin {
         create("rewrite") {
             id = "org.openrewrite.rewrite"
             displayName = "Rewrite"
-            description = "Automatically eliminate technical debt. Apply OpenRewrite recipes to refactor, migrate, and fix source code across Java, Kotlin, Gradle, XML, YAML, properties, and more."
+            description = "Automatically eliminate technical debt. " +
+                    "Apply OpenRewrite recipes to refactor, migrate, and fix source code across Java, Kotlin, Gradle, XML, YAML, properties, and more. " +
+                    "Provides rewriteRun (apply recipes), rewriteDryRun (preview changes as a patch file), and rewriteDiscover (list available recipes) tasks. " +
+                    "Configure active recipes and styles through the rewrite DSL or a rewrite.yml file."
             implementationClass = "org.openrewrite.gradle.RewritePlugin"
             tags.set(listOf("rewrite", "refactoring", "remediation", "security", "migration", "java", "checkstyle"))
         }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java
@@ -24,7 +24,7 @@ public class RewriteDiscoverTask extends AbstractRewriteTask {
     @Inject
     public RewriteDiscoverTask() {
         setGroup("rewrite");
-        setDescription("Lists all available recipes and their visitors");
+        setDescription("Lists all available recipes, their visitors, and active recipes configured in the rewrite DSL or rewrite.yml");
     }
 
     @TaskAction

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -102,7 +102,7 @@ public class RewriteExtension {
     private final List<String> plainTextMasks = new ArrayList<>();
 
     /**
-     * Maximum file size in megabytes. Non-Java source files larger than this threshold are skipped during parsing.
+     * Maximum file size in megabytes. Source files larger than this threshold are skipped during parsing.
      * Defaults to {@code 10}.
      */
     private int sizeThresholdMb = 10;

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -127,7 +127,7 @@ public class RewriteExtension {
      * Whether to throw an exception if an activeRecipe fails configuration validation.
      * This may happen if the activeRecipe is improperly configured, or any downstream recipes are improperly configured.
      * <p>
-     * For the time, this default is "false" to prevent one improperly recipe from failing the build.
+     * For the time, this default is "false" to prevent one improperly configured recipe from failing the build.
      * In the future, this default may be changed to "true" to be more restrictive.
      */
     private boolean failOnInvalidActiveRecipes;

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -27,14 +27,39 @@ import java.util.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 
+/**
+ * DSL extension for configuring the OpenRewrite Gradle plugin.
+ * <p>
+ * Configured via the {@code rewrite} block in a Gradle build script:
+ * <pre>
+ * rewrite {
+ *     activeRecipe("org.openrewrite.java.format.AutoFormat")
+ *     exclusion("src/generated/**")
+ * }
+ * </pre>
+ */
 @SuppressWarnings("unused")
 public class RewriteExtension {
 
+    /**
+     * Fully qualified class names of recipes to activate.
+     * Recipes will only run when explicitly activated here or in a rewrite.yml file.
+     */
     private final List<String> activeRecipes = new ArrayList<>();
+
+    /**
+     * Fully qualified class names of styles to activate.
+     * Styles will only be applied when explicitly activated here or in a rewrite.yml file.
+     */
     private final List<String> activeStyles = new ArrayList<>();
     private boolean configFileSetDeliberately;
 
     protected final Project project;
+
+    /**
+     * Path to the OpenRewrite YAML configuration file.
+     * Defaults to {@code rewrite.yml} in the project directory.
+     */
     private File configFile;
 
     @Nullable
@@ -43,21 +68,59 @@ public class RewriteExtension {
     @Nullable
     private Provider<Map<String, Object>> checkstylePropertiesProvider;
 
+    /**
+     * Optional path to a Checkstyle configuration file. When set, OpenRewrite will use it
+     * to inform Java code style decisions. If not set explicitly, the plugin will attempt
+     * to auto-detect a Checkstyle configuration from the Checkstyle Gradle plugin.
+     */
     @Nullable
     private File checkstyleConfigFile;
+
+    /**
+     * Whether to parse Gradle build scripts ({@code build.gradle}) as part of the source set.
+     * Defaults to {@code true}.
+     */
     private boolean enableExperimentalGradleBuildScriptParsing = true;
+
+    /**
+     * Whether to export data tables to {@code <build directory>/reports/rewrite/datatables/<timestamp>}.
+     * Defaults to {@code false}.
+     */
     private boolean exportDatatables;
+
+    /**
+     * Glob patterns for files to exclude from processing.
+     * For example: {@code "src/generated/**"}.
+     */
     private final List<String> exclusions = new ArrayList<>();
+
+    /**
+     * Glob patterns for files that should be parsed as plain text.
+     * Defaults to a comprehensive list including {@code **&#47;*.md}, {@code **&#47;*.sql}, {@code **&#47;*.txt}, and others.
+     * Exclusions take precedence over plain text masks.
+     */
     private final List<String> plainTextMasks = new ArrayList<>();
 
+    /**
+     * Maximum file size in megabytes. Non-Java source files larger than this threshold are skipped during parsing.
+     * Defaults to {@code 10}.
+     */
     private int sizeThresholdMb = 10;
 
+    /**
+     * Override the version of rewrite core libraries to be used.
+     * When {@code null}, the version bundled with the plugin is used.
+     */
     @Nullable
     private String rewriteVersion;
 
     @Nullable
     private Properties versionProps;
 
+    /**
+     * Whether to log Java compilation warnings and errors encountered during parsing.
+     * Defaults to {@code false}.
+     */
     private boolean logCompilationWarningsAndErrors;
 
     /**
@@ -69,8 +132,18 @@ public class RewriteExtension {
      */
     private boolean failOnInvalidActiveRecipes;
 
+    /**
+     * Whether {@code rewriteDryRun} should fail the build when it detects that changes would be made.
+     * Useful in CI to enforce that all recipes have already been applied.
+     * Defaults to {@code false}.
+     */
     private boolean failOnDryRunResults;
 
+    /**
+     * Whether to throw an exception when source file parsing fails.
+     * Can also be enabled via the project property {@code -Prewrite.throwOnParseFailures}.
+     * Defaults to {@code false}.
+     */
     private boolean throwOnParseFailures;
 
     @SuppressWarnings("unused")

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
@@ -28,7 +28,7 @@ public class RewriteRunTask extends AbstractRewriteTask {
     @Inject
     public RewriteRunTask() {
         setGroup("rewrite");
-        setDescription("Apply the active refactoring recipes");
+        setDescription("Apply the active refactoring recipes. Source files will be modified in place.");
     }
 
     @TaskAction

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/DocumentationSyncTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/DocumentationSyncTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class DocumentationSyncTest {
+
+    private val extensionSource = File("src/main/java/org/openrewrite/gradle/RewriteExtension.java").readText()
+
+    /**
+     * User-facing properties on RewriteExtension that must have Javadoc.
+     * Internal/provider properties are excluded.
+     */
+    private val userFacingFields = listOf(
+        "activeRecipes",
+        "activeStyles",
+        "configFile",
+        "checkstyleConfigFile",
+        "enableExperimentalGradleBuildScriptParsing",
+        "exportDatatables",
+        "exclusions",
+        "plainTextMasks",
+        "sizeThresholdMb",
+        "rewriteVersion",
+        "logCompilationWarningsAndErrors",
+        "failOnInvalidActiveRecipes",
+        "failOnDryRunResults",
+        "throwOnParseFailures",
+    )
+
+    @Test
+    fun `all user-facing RewriteExtension fields have Javadoc`() {
+        val fieldPattern = Regex("""(?s)/\*\*.*?\*/\s*(?:@\w+\s+)*(?:private|public|protected)\s+.*?\b(\w+)\s*[;=]""")
+        val documentedFields = fieldPattern.findAll(extensionSource)
+            .map { it.groupValues[1] }
+            .toSet()
+
+        val undocumented = userFacingFields.filter { it !in documentedFields }
+        assertThat(undocumented)
+            .withFailMessage("The following RewriteExtension fields are missing Javadoc:\n${undocumented.joinToString("\n") { "  - $it" }}")
+            .isEmpty()
+    }
+
+    @Test
+    fun `all task classes have non-empty descriptions`() {
+        val taskFiles = listOf(
+            "src/main/java/org/openrewrite/gradle/RewriteRunTask.java",
+            "src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java",
+            "src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java",
+        )
+        for (path in taskFiles) {
+            val source = File(path).readText()
+            assertThat(source)
+                .withFailMessage("$path does not call setDescription()")
+                .contains("setDescription(")
+            val desc = Regex("""setDescription\("(.+?)"\)""").find(source)?.groupValues?.get(1)
+            assertThat(desc)
+                .withFailMessage("$path has an empty task description")
+                .isNotBlank()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive Javadoc to all 14 user-facing fields in `RewriteExtension`, documenting descriptions, defaults, and behavioral notes
- Improve task descriptions for `rewriteRun` and `rewriteDiscover` to be more informative in `gradle tasks` / `gradle help --task` output
- Enrich the Gradle Plugin Portal description beyond "Automatically eliminate technical debt"
- Add `DocumentationSyncTest` that verifies all user-facing extension fields have Javadoc and all tasks have non-empty descriptions, preventing future documentation drift

- Closes #215

## Test plan
- [x] `DocumentationSyncTest` passes: all fields have Javadoc, all tasks have descriptions
- [ ] Verify `gradle tasks` shows improved task descriptions
- [ ] Verify Javadoc renders correctly in IDEs