### PR TITLE
Generate plugin reference docs and deploy via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,57 @@
+---
+name: Deploy plugin docs to Pages
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch: {}
+  workflow_run:
+    workflows: ["publish"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          develocity-access-key: ${{ env.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      - name: Generate documentation
+        run: ./gradlew :plugin:test --tests "org.openrewrite.gradle.DocumentationSyncTest" :plugin:javadoc
+
+      - name: Assemble site
+        run: |
+          mkdir -p site/apidocs
+          cp docs/plugin-reference.md site/index.md
+          cp -r plugin/build/docs/javadoc/* site/apidocs/
+
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+      - uses: actions/deploy-pages@v5

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -1,0 +1,52 @@
+# OpenRewrite Gradle Plugin Reference
+
+Automatically eliminate technical debt. Apply OpenRewrite recipes to refactor, migrate, and fix source code across Java, Kotlin, Gradle, XML, YAML, properties, and more.
+
+## Tasks
+
+### `rewriteRun`
+
+Apply the active refactoring recipes. Source files will be modified in place.
+
+### `rewriteDryRun`
+
+Run the active refactoring recipes, producing a patch file. No source files will be changed.
+
+### `rewriteDiscover`
+
+Lists all available recipes, their visitors, and active recipes configured in the rewrite DSL or rewrite.yml
+
+## Configuration
+
+The plugin is configured via the `rewrite` DSL block in your `build.gradle` or `build.gradle.kts`:
+
+```groovy
+rewrite {
+    activeRecipe("org.openrewrite.java.format.AutoFormat")
+    exclusion("src/generated/**")
+}
+```
+
+### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `activeRecipes` | `List<String>` | Empty list | Fully qualified class names of recipes to activate. Recipes will only run when explicitly activated here or in a rewrite.yml file. |
+| `activeStyles` | `List<String>` | Empty list | Fully qualified class names of styles to activate. Styles will only be applied when explicitly activated here or in a rewrite.yml file. |
+| `configFile` | `File` | `rewrite.yml` | Path to the OpenRewrite YAML configuration file. Defaults to `rewrite.yml` in the project directory. |
+| `checkstyleConfigFile` | `File` | `null` | Optional path to a Checkstyle configuration file. When set, OpenRewrite will use it to inform Java code style decisions. If not set explicitly, the plugin will attempt to auto-detect a Checkstyle configuration from the Checkstyle Gradle plugin. |
+| `enableExperimentalGradleBuildScriptParsing` | `boolean` | `true` | Whether to parse Gradle build scripts (`build.gradle`) as part of the source set. Defaults to `true`. |
+| `exportDatatables` | `boolean` | `false` | Whether to export data tables to `<build directory>/reports/rewrite/datatables/<timestamp>`. Defaults to `false`. |
+| `exclusions` | `List<String>` | Empty list | Glob patterns for files to exclude from processing. For example: `"src/generated/**"`. |
+| `plainTextMasks` | `List<String>` | Empty list | Glob patterns for files that should be parsed as plain text. Defaults to a comprehensive list including `**/*.md`, `**/*.sql`, `**/*.txt`, and others. Exclusions take precedence over plain text masks. |
+| `sizeThresholdMb` | `int` | `10` | Maximum file size in megabytes. Source files larger than this threshold are skipped during parsing. Defaults to `10`. |
+| `rewriteVersion` | `String` | `null` | Override the version of rewrite core libraries to be used. When `null`, the version bundled with the plugin is used. |
+| `logCompilationWarningsAndErrors` | `boolean` | `false` | Whether to log Java compilation warnings and errors encountered during parsing. Defaults to `false`. |
+| `failOnInvalidActiveRecipes` | `boolean` | `false` | Whether to throw an exception if an activeRecipe fails configuration validation. This may happen if the activeRecipe is improperly configured, or any downstream recipes are improperly configured. For the time, this default is "false" to prevent one improperly configured recipe from failing the build. In the future, this default may be changed to "true" to be more restrictive. |
+| `failOnDryRunResults` | `boolean` | `false` | Whether `rewriteDryRun` should fail the build when it detects that changes would be made. Useful in CI to enforce that all recipes have already been applied. Defaults to `false`. |
+| `throwOnParseFailures` | `boolean` | `false` | Whether to throw an exception when source file parsing fails. Can also be enabled via the project property `-Prewrite.throwOnParseFailures`. Defaults to `false`. |
+
+## Javadoc
+
+Full API documentation is available in the [Javadoc](apidocs/index.html).
+

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -218,6 +218,15 @@ tasks.named("check").configure {
     dependsOn(testGradle4, testGradle8)
 }
 
+tasks.withType<Javadoc>().configureEach {
+    title = "OpenRewrite Gradle Plugin API"
+    (options as StandardJavadocDocletOptions).apply {
+        addStringOption("Xdoclint:none", "-quiet")
+        links("https://docs.gradle.org/current/javadoc/")
+        links("https://docs.oracle.com/en/java/javase/17/docs/api/")
+    }
+}
+
 configure<LicenseExtension> {
     ext.set("year", Calendar.getInstance().get(Calendar.YEAR))
     skipExistingHeaders = true

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/DocumentationSyncTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/DocumentationSyncTest.kt
@@ -75,4 +75,121 @@ class DocumentationSyncTest {
                 .isNotBlank()
         }
     }
+
+    private val taskClasses = listOf(
+        "src/main/java/org/openrewrite/gradle/RewriteRunTask.java" to "rewriteRun",
+        "src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java" to "rewriteDryRun",
+        "src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java" to "rewriteDiscover",
+    )
+
+    @Test
+    fun `generated plugin reference is up to date`() {
+        val generated = generatePluginReference()
+        val referenceFile = File("../docs/plugin-reference.md")
+
+        // Always write the file so it stays in sync
+        referenceFile.parentFile.mkdirs()
+        referenceFile.writeText(generated)
+    }
+
+    private fun generatePluginReference(): String {
+        val sb = StringBuilder()
+        sb.appendLine("# OpenRewrite Gradle Plugin Reference")
+        sb.appendLine()
+        sb.appendLine("Automatically eliminate technical debt. Apply OpenRewrite recipes to refactor, migrate, and fix source code across Java, Kotlin, Gradle, XML, YAML, properties, and more.")
+        sb.appendLine()
+        sb.appendLine("## Tasks")
+        sb.appendLine()
+
+        for ((path, taskName) in taskClasses) {
+            val source = File(path).readText()
+            val description = Regex("""setDescription\("(.+?)"\)""").find(source)!!.groupValues[1]
+            sb.appendLine("### `$taskName`")
+            sb.appendLine()
+            sb.appendLine(description)
+            sb.appendLine()
+        }
+
+        sb.appendLine("## Configuration")
+        sb.appendLine()
+        sb.appendLine("The plugin is configured via the `rewrite` DSL block in your `build.gradle` or `build.gradle.kts`:")
+        sb.appendLine()
+        sb.appendLine("```groovy")
+        sb.appendLine("rewrite {")
+        sb.appendLine("    activeRecipe(\"org.openrewrite.java.format.AutoFormat\")")
+        sb.appendLine("    exclusion(\"src/generated/**\")")
+        sb.appendLine("}")
+        sb.appendLine("```")
+        sb.appendLine()
+        sb.appendLine("### Properties")
+        sb.appendLine()
+        sb.appendLine("| Property | Type | Default | Description |")
+        sb.appendLine("|----------|------|---------|-------------|")
+
+        // Match Javadoc comment followed by optional annotations and a field declaration.
+        // The Javadoc must start at the beginning of a line (after optional whitespace).
+        val javadocFieldPattern = Regex("""(?m)^\s*/\*\*\n((?:\s*\*.*\n)*?)\s*\*/\n(?:\s*@\w+(?:\(.*?\))?\s*\n)*\s*(?:private|public|protected)\s+([\w<>,\s]+?)\s+(\w+)\s*([;=].*)""")
+
+        for (match in javadocFieldPattern.findAll(extensionSource)) {
+            val rawJavadoc = match.groupValues[1]
+            val fieldType = match.groupValues[2].trim()
+            val fieldName = match.groupValues[3]
+            val rest = match.groupValues[4]
+            val initializer = if (rest.startsWith("=")) {
+                rest.drop(1).trimEnd(';').trim()
+            } else {
+                ""
+            }
+
+            if (fieldName !in userFacingFields) continue
+
+            // Clean up Javadoc: strip * prefixes, {@code ...} -> `...`, collapse whitespace
+            val javadoc = rawJavadoc
+                .lines()
+                .joinToString(" ") { it.trimStart().removePrefix("* ").removePrefix("*").trim() }
+                .replace(Regex("""\{@code\s+(.*?)\}"""), "`$1`")
+                .replace(Regex("""\{@link\s+#?\S+\s+(.*?)\}"""), "$1")
+                .replace(Regex("""\{@link\s+(.*?)\}"""), "`$1`")
+                .replace(Regex("""\s*<p>\s*"""), " ")
+                .replace(Regex("""\s*<pre>.*?</pre>\s*"""), " ")
+                .replace("&#47;", "/")
+                .replace(Regex("""\s+"""), " ")
+                .trim()
+
+            // Determine display type
+            val displayType = when {
+                fieldType.contains("List<String>") -> "`List<String>`"
+                fieldType.contains("boolean") -> "`boolean`"
+                fieldType.contains("int") -> "`int`"
+                fieldType.contains("String") -> "`String`"
+                fieldType.contains("File") -> "`File`"
+                else -> "`$fieldType`"
+            }
+
+            // Determine default value from field initializer, with overrides for constructor-set fields
+            val default = when (fieldName) {
+                "configFile" -> "`rewrite.yml`"
+                else -> when {
+                    initializer.startsWith("new ArrayList") -> "Empty list"
+                    initializer == "true" -> "`true`"
+                    initializer == "false" -> "`false`"
+                    initializer.matches(Regex("\\d+")) -> "`$initializer`"
+                    fieldType.contains("boolean") && initializer.isEmpty() -> "`false`"
+                    fieldType.contains("String") && initializer.isEmpty() -> "`null`"
+                    fieldType.contains("File") && initializer.isEmpty() -> "`null`"
+                    else -> ""
+                }
+            }
+
+            sb.appendLine("| `$fieldName` | $displayType | $default | $javadoc |")
+        }
+
+        sb.appendLine()
+        sb.appendLine("## Javadoc")
+        sb.appendLine()
+        sb.appendLine("Full API documentation is available in the [Javadoc](apidocs/index.html).")
+        sb.appendLine()
+
+        return sb.toString()
+    }
 }


### PR DESCRIPTION
## Summary

- Extend `DocumentationSyncTest` to generate a Markdown plugin reference page (`docs/plugin-reference.md`) from `RewriteExtension` Javadoc and task descriptions, covering all 14 configuration properties and 3 tasks
- Configure the built-in Javadoc task in `build.gradle.kts` with proper title and API links for full HTML API documentation
- Add a GitHub Pages workflow (`.github/workflows/pages.yml`) that publishes both the curated Markdown reference and full Javadoc on version tags, mirroring the approach used in rewrite-maven-plugin
- Closes https://github.com/openrewrite/rewrite-gradle-plugin/issues/215

## Test plan
- [x] `./gradlew :plugin:test --tests "org.openrewrite.gradle.DocumentationSyncTest"` passes
- [x] `./gradlew :plugin:javadoc` generates HTML output
- [ ] Verify GitHub Pages deployment after first version tag