### PR TITLE
Convert GitHub Pages index to HTML using pandoc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Assemble site
         run: |
           mkdir -p site/apidocs
-          cp docs/plugin-reference.md site/index.md
+          sudo apt-get install -y pandoc
+          pandoc docs/plugin-reference.md -s --metadata title="OpenRewrite Gradle Plugin Reference" -o site/index.html
           cp -r plugin/build/docs/javadoc/* site/apidocs/
 
       - uses: actions/configure-pages@v6


### PR DESCRIPTION
## Summary
- Use pandoc to convert `plugin-reference.md` to `index.html` in the Pages workflow, so the site serves rendered HTML instead of raw markdown.

## Test plan
- [ ] Trigger the Pages workflow manually and verify the deployed site renders as HTML