### PR TITLE
Fix HTML table width in GitHub Pages documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,8 @@ jobs:
         run: |
           mkdir -p site/apidocs
           sudo apt-get install -y pandoc
-          pandoc docs/plugin-reference.md -s --metadata title="OpenRewrite Gradle Plugin Reference" -o site/index.html
+          pandoc docs/plugin-reference.md -s --metadata title="OpenRewrite Gradle Plugin Reference" --css style.css -o site/index.html
+          cp docs/style.css site/
           cp -r plugin/build/docs/javadoc/* site/apidocs/
 
       - uses: actions/configure-pages@v6

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,7 @@
+body {
+  max-width: none;
+  padding: 0 2em;
+}
+table {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- Pandoc's default standalone HTML constrains the body to a narrow `max-width`, cutting off the properties table
- Adds a `docs/style.css` that removes the max-width constraint and sets tables to full width
- Updates the Pages workflow to include the stylesheet in the pandoc output and copy it to the site