### PR TITLE
Add testGradle9 task pinned to Gradle 9.4.1 on Java 25

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -215,13 +215,12 @@ val testGradle8 = tasks.register<Test>("testGradle8") {
     })
 }
 val testGradle9 = tasks.register<Test>("testGradle9") {
-    systemProperty("org.openrewrite.test.gradleVersion", "9.0.0")
+    systemProperty("org.openrewrite.test.gradleVersion", "9.4.1")
     systemProperty("jarLocationForTest", tasks.named<Jar>("jar").get().archiveFile.get().asFile.absolutePath)
     testClassesDirs = files(testJvmTestSuite.map { it.sources.output.classesDirs })
     classpath = files(testJvmTestSuite.map { it.sources.runtimeClasspath})
-    // Gradle 9.0 predates support for Java 25
     javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     })
 }
 tasks.named("check").configure {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -214,8 +214,18 @@ val testGradle8 = tasks.register<Test>("testGradle8") {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
 }
+val testGradle9 = tasks.register<Test>("testGradle9") {
+    systemProperty("org.openrewrite.test.gradleVersion", "9.0.0")
+    systemProperty("jarLocationForTest", tasks.named<Jar>("jar").get().archiveFile.get().asFile.absolutePath)
+    testClassesDirs = files(testJvmTestSuite.map { it.sources.output.classesDirs })
+    classpath = files(testJvmTestSuite.map { it.sources.runtimeClasspath})
+    // Gradle 9.0 predates support for Java 25
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    })
+}
 tasks.named("check").configure {
-    dependsOn(testGradle4, testGradle8)
+    dependsOn(testGradle4, testGradle8, testGradle9)
 }
 
 tasks.withType<Javadoc>().configureEach {

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -1041,6 +1041,9 @@ class RewriteRunTest : RewritePluginTest {
                        url = uri("https://central.sonatype.com/repository/maven-snapshots")
                     }
                 }
+                kotlin {
+                    jvmToolchain(21)
+                }
                 rewrite {
                     activeRecipe("org.openrewrite.test.FindString")
                 }


### PR DESCRIPTION
## Summary
- Adds a `testGradle9` task modeled on the existing `testGradle4` / `testGradle8` tasks, pinned to Gradle `9.4.1` (the current stable release; 9.5 is still in RC).
- Runs the suite on a Java 25 toolchain, since Gradle 9.1+ supports Java 25 at runtime.
- Wires the task into `check`, so CI (which runs `./gradlew build`) picks it up automatically — no workflow change needed.

## Why
The default `test` task runs against whatever Gradle version the wrapper ships (currently 9.3.1). The dedicated `testGradleN` tasks exist to pin coverage against specific Gradle versions so wrapper upgrades don't silently change our support surface. With Gradle 9.5.0-rc-3 out and the wrapper about to move forward along 9.x, pinning 9.4.1 gives us a deliberate "latest stable 9.x" target, mirroring how `testGradle8` pins the latest 8.x.

## Test plan
- [x] `./gradlew :plugin:tasks --all` shows `testGradle9` registered.
- [x] `./gradlew :plugin:check --dry-run` shows `testGradle4`, `testGradle8`, and `testGradle9` scheduled.
- [ ] CI runs `testGradle9` as part of `build` on Java 25 and passes.