### PR TITLE
Honor throwOnParseFailures option (#441)

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1428,6 +1428,9 @@ public class DefaultProjectParser implements GradleProjectParser {
                 })
                 .peek(xmlDetector::sample)
                 .collect(toList());
+        if (extension.getThrowOnParseFailures() && firstWarningLogged.get()) {
+            throw new RuntimeException("There were problems parsing some source files, run with --info to see full stack traces. Fix the parse failures or set throwOnParseFailures to false to continue.");
+        }
         Map<Class<? extends SourceFile>, NamedStyles> stylesByType = new HashMap<>();
         stylesByType.put(J.CompilationUnit.class, javaDetector.build());
         stylesByType.put(K.CompilationUnit.class, kotlinDetector.build());

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/GradleRunnerTest.kt
@@ -25,6 +25,14 @@ val gradleVersion: String? = System.getProperty("org.openrewrite.test.gradleVers
 interface GradleRunnerTest {
 
     fun runGradle(testDir: File, vararg args: String): BuildResult {
+        return gradleRunner(testDir, *args).build()
+    }
+
+    fun runGradleAndFail(testDir: File, vararg args: String): BuildResult {
+        return gradleRunner(testDir, *args).buildAndFail()
+    }
+
+    private fun gradleRunner(testDir: File, vararg args: String): GradleRunner {
         return GradleRunner.create()
             .withDebug(ManagementFactory.getRuntimeMXBean().inputArguments.toString().indexOf("-agentlib:jdwp") > 0)
             .withProjectDir(testDir)
@@ -36,6 +44,5 @@ interface GradleRunnerTest {
             .withArguments(*args, "--info", "--stacktrace")
             .withPluginClasspath()
             .forwardOutput()
-            .build()
     }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
@@ -348,6 +348,43 @@ class RewriteDryRunTest : RewritePluginTest {
             )
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-gradle-plugin/issues/441")
+    @Test
+    fun `throwOnParseFailures fails the build when parsing fails`() {
+        gradleProject(projectDir) {
+            buildGradle(
+                """
+                plugins {
+                    id("org.openrewrite.rewrite")
+                }
+
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
+                    }
+                }
+
+                rewrite {
+                    activeRecipe("org.openrewrite.FindSourceFiles")
+                    throwOnParseFailures = true
+                }
+                """
+            )
+            textFile(
+                "broken.yml",
+                """
+                key: value
+                  - invalid indentation
+                    foo: [unclosed
+                """.trimIndent()
+            )
+        }
+        val result = runGradleAndFail(projectDir, taskName())
+        assertThat(result.output).contains("Fix the parse failures or set throwOnParseFailures to false to continue")
+    }
+
     @EnabledIfEnvironmentVariable(named = "ANDROID_HOME", matches = ".*")
     @EnabledForGradleRange(min = "5.0", max = "7.6.4")
     @Test


### PR DESCRIPTION
## Summary
- Wire up `throwOnParseFailures` in `DefaultProjectParser.listResults` so the build actually fails when parse errors occur — previously the option was defined with getters/setters but never consulted.
- Add a regression test that confirms a malformed file with `throwOnParseFailures = true` fails the build, and a `runGradleAndFail` helper to support it.

- Fixes #441

## Test plan
- [x] `./gradlew :plugin:test --tests "org.openrewrite.gradle.RewriteDryRunTest"`