### PR TITLE
Persist pom lookups in rocksdb pom cache, matching the behavior of the maven plugin.

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     "rewriteDependencies"("org.openrewrite:rewrite-maven")
     "rewriteDependencies"("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2")
     "rewriteDependencies"("com.google.guava:guava:latest.release")
+    "rewriteDependencies"("org.rocksdb:rocksdbjni:8.8.1")
     implementation(platform("org.openrewrite:rewrite-bom:$latest"))
     compileOnly("com.android.tools.build:gradle:7.0.4")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:latest.release")

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteExtension.java
@@ -146,6 +146,20 @@ public class RewriteExtension {
      */
     private boolean throwOnParseFailures;
 
+    /**
+     * Whether to cache resolved Maven POMs to a RocksDB-backed on-disk cache to speed up subsequent recipe runs.
+     * When {@code true} (the default), a two-layer cache is used: an in-memory L1 cache backed by a RocksDB L2 cache.
+     * When {@code false}, only an in-memory cache is used.
+     */
+    private boolean pomCacheEnabled = true;
+
+    /**
+     * Directory in which to store the RocksDB-backed Maven POM cache.
+     * When {@code null} (the default), the cache is stored under {@code ~/.rewrite-cache}.
+     */
+    @Nullable
+    private String pomCacheDirectory;
+
     @SuppressWarnings("unused")
     public RewriteExtension(Project project) {
         this.project = project;
@@ -409,6 +423,10 @@ public class RewriteExtension {
         return getVersionProps().getProperty("com.fasterxml.jackson.module:jackson-module-kotlin");
     }
 
+    public String getRocksdbJniVersion() {
+        return getVersionProps().getProperty("org.rocksdb:rocksdbjni");
+    }
+
     public boolean getThrowOnParseFailures() {
         if (project.getProperties().containsKey("rewrite.throwOnParseFailures")) {
             return true;
@@ -418,5 +436,21 @@ public class RewriteExtension {
 
     public void setThrowOnParseFailures(boolean throwOnParseFailures) {
         this.throwOnParseFailures = throwOnParseFailures;
+    }
+
+    public boolean getPomCacheEnabled() {
+        return pomCacheEnabled;
+    }
+
+    public void setPomCacheEnabled(boolean pomCacheEnabled) {
+        this.pomCacheEnabled = pomCacheEnabled;
+    }
+
+    public @Nullable String getPomCacheDirectory() {
+        return pomCacheDirectory;
+    }
+
+    public void setPomCacheDirectory(@Nullable String pomCacheDirectory) {
+        this.pomCacheDirectory = pomCacheDirectory;
     }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -225,7 +225,8 @@ public class RewritePlugin implements Plugin<Project> {
                 deps.create("org.openrewrite:rewrite-polyglot:" + extension.getRewritePolyglotVersion()),
                 deps.create("org.openrewrite.gradle.tooling:model:" + extension.getRewriteGradleModelVersion()),
                 deps.create("com.fasterxml.jackson.module:jackson-module-kotlin:" + extension.getJacksonModuleKotlinVersion()),
-                deps.create("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:" + extension.getJacksonModuleKotlinVersion())
+                deps.create("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:" + extension.getJacksonModuleKotlinVersion()),
+                deps.create("org.rocksdb:rocksdbjni:" + extension.getRocksdbJniVersion())
         );
     }
 }

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -74,6 +74,9 @@ import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.*;
 import org.openrewrite.marker.ci.BuildEnvironment;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.MavenPomCache;
 import org.openrewrite.polyglot.*;
 import org.openrewrite.properties.PropertiesParser;
 import org.openrewrite.quark.Quark;
@@ -111,6 +114,7 @@ public class DefaultProjectParser implements GradleProjectParser {
     private static final String LOG_INDENT_INCREMENT = "    ";
 
     private static final Logger logger = Logging.getLogger(DefaultProjectParser.class);
+    private static @Nullable MavenPomCache pomCache;
     private final AtomicBoolean firstWarningLogged = new AtomicBoolean(false);
     protected final Path baseDir;
     protected final RewriteExtension extension;
@@ -1392,6 +1396,9 @@ public class DefaultProjectParser implements GradleProjectParser {
     }
 
     protected ResultsContainer listResults(ExecutionContext ctx) {
+        if (extension.getPomCacheEnabled()) {
+            MavenExecutionContextView.view(ctx).setPomCache(getPomCache(extension.getPomCacheDirectory()));
+        }
         Environment env = environment();
         Recipe recipe = env.activateRecipes(getActiveRecipes());
         if ("org.openrewrite.Recipe$Noop".equals(recipe.getName())) {
@@ -1459,6 +1466,16 @@ public class DefaultProjectParser implements GradleProjectParser {
         if (repository != null) {
             repository.close();
         }
+    }
+
+    private static synchronized MavenPomCache getPomCache(@Nullable String pomCacheDirectory) {
+        if (pomCache == null) {
+            pomCache = new MavenPomCacheBuilder(logger).build(pomCacheDirectory);
+        }
+        if (pomCache == null) {
+            pomCache = new InMemoryMavenPomCache();
+        }
+        return pomCache;
     }
 
     private UnaryOperator<SourceFile> applyAutodetected(

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/MavenPomCacheBuilder.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/MavenPomCacheBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.isolated;
+
+import org.gradle.api.logging.Logger;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.maven.cache.CompositeMavenPomCache;
+import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.MavenPomCache;
+import org.openrewrite.maven.cache.RocksdbMavenPomCache;
+
+import java.nio.file.Paths;
+
+class MavenPomCacheBuilder {
+    private final Logger logger;
+
+    MavenPomCacheBuilder(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Nullable MavenPomCache build(@Nullable String pomCacheDirectory) {
+        if (isJvm64Bit()) {
+            try {
+                if (pomCacheDirectory == null) {
+                    //Default directory in the RocksdbMavenPomCache is ".rewrite-cache"
+                    return new CompositeMavenPomCache(
+                            new InMemoryMavenPomCache(),
+                            new RocksdbMavenPomCache(Paths.get(System.getProperty("user.home")))
+                    );
+                }
+                return new CompositeMavenPomCache(
+                        new InMemoryMavenPomCache(),
+                        new RocksdbMavenPomCache(Paths.get(pomCacheDirectory))
+                );
+            } catch (Throwable e) {
+                logger.warn("Unable to initialize RocksdbMavenPomCache, falling back to InMemoryMavenPomCache");
+                logger.debug("Unable to initialize RocksdbMavenPomCache", e);
+            }
+        } else {
+            logger.warn("RocksdbMavenPomCache is not supported on 32-bit JVM. Falling back to InMemoryMavenPomCache");
+        }
+
+        return null;
+    }
+
+    private static boolean isJvm64Bit() {
+        //It appears most JVM vendors set this property. Only return false if the
+        //property has been set AND it is set to 32.
+        return !"32".equals(System.getProperty("sun.arch.data.model", "64"));
+    }
+}

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -787,6 +787,64 @@ class RewriteRunTest : RewritePluginTest {
     }
 
     @Test
+    fun pomCacheEnabledPersistsToConfiguredDirectory(@TempDir projectDir: File) {
+        val cacheDir = projectDir.resolve("rewrite-cache").absolutePath.replace("\\", "\\\\")
+        gradleProject(projectDir) {
+            rewriteYaml(
+                """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: org.openrewrite.test.UpgradeJacksonCore
+                displayName: Upgrade jackson-core
+                description: Upgrade jackson-core.
+                recipeList:
+                  - org.openrewrite.gradle.UpgradeDependencyVersion:
+                      groupId: com.fasterxml.jackson.core
+                      artifactId: jackson-core
+                      newVersion: 2.16.0
+            """
+            )
+            buildGradle(
+                """
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                }
+
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
+                    }
+                }
+
+                dependencies {
+                    implementation("com.fasterxml.jackson.core:jackson-core:2.15.1")
+                }
+
+                rewrite {
+                    pomCacheEnabled = true
+                    pomCacheDirectory = "$cacheDir"
+                    activeRecipe("org.openrewrite.test.UpgradeJacksonCore")
+                }
+            """
+            )
+        }
+
+        val result = runGradle(projectDir, taskName())
+        val rewriteRunResult = result.task(":${taskName()}")!!
+        assertThat(rewriteRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(projectDir.resolve("build.gradle").readText())
+            .contains("com.fasterxml.jackson.core:jackson-core:2.16.0")
+
+        // RocksdbMavenPomCache writes its database under a `.rewrite-cache` subdirectory
+        val rocksDir = projectDir.resolve("rewrite-cache").resolve(".rewrite-cache")
+        assertThat(rocksDir).exists().isDirectory()
+        assertThat(rocksDir.list()).isNotEmpty()
+    }
+
+    @Test
     fun mergeConfiguredAndAutodetectedStyles(@TempDir projectDir: File) {
         gradleProject(projectDir) {
             propertiesFile("gradle.properties", "systemProp.rewrite.activeStyles=org.openrewrite.testStyle")

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -787,64 +787,6 @@ class RewriteRunTest : RewritePluginTest {
     }
 
     @Test
-    fun pomCacheEnabledPersistsToConfiguredDirectory(@TempDir projectDir: File) {
-        val cacheDir = projectDir.resolve("rewrite-cache").absolutePath.replace("\\", "\\\\")
-        gradleProject(projectDir) {
-            rewriteYaml(
-                """
-                type: specs.openrewrite.org/v1beta/recipe
-                name: org.openrewrite.test.UpgradeJacksonCore
-                displayName: Upgrade jackson-core
-                description: Upgrade jackson-core.
-                recipeList:
-                  - org.openrewrite.gradle.UpgradeDependencyVersion:
-                      groupId: com.fasterxml.jackson.core
-                      artifactId: jackson-core
-                      newVersion: 2.16.0
-            """
-            )
-            buildGradle(
-                """
-                plugins {
-                    id("java")
-                    id("org.openrewrite.rewrite")
-                }
-
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
-
-                dependencies {
-                    implementation("com.fasterxml.jackson.core:jackson-core:2.15.1")
-                }
-
-                rewrite {
-                    pomCacheEnabled = true
-                    pomCacheDirectory = "$cacheDir"
-                    activeRecipe("org.openrewrite.test.UpgradeJacksonCore")
-                }
-            """
-            )
-        }
-
-        val result = runGradle(projectDir, taskName())
-        val rewriteRunResult = result.task(":${taskName()}")!!
-        assertThat(rewriteRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        assertThat(projectDir.resolve("build.gradle").readText())
-            .contains("com.fasterxml.jackson.core:jackson-core:2.16.0")
-
-        // RocksdbMavenPomCache writes its database under a `.rewrite-cache` subdirectory
-        val rocksDir = projectDir.resolve("rewrite-cache").resolve(".rewrite-cache")
-        assertThat(rocksDir).exists().isDirectory()
-        assertThat(rocksDir.list()).isNotEmpty()
-    }
-
-    @Test
     fun mergeConfiguredAndAutodetectedStyles(@TempDir projectDir: File) {
         gradleProject(projectDir) {
             propertiesFile("gradle.properties", "systemProp.rewrite.activeStyles=org.openrewrite.testStyle")


### PR DESCRIPTION
I can't think of any reason why we didn't do this years ago when we added it to the maven plugin. Apparent oversight.