### PR TITLE
Bump test project metaspace to avoid OOM in test-kit daemons

### DIFF
--- a/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
@@ -161,6 +161,10 @@ class GradleProjectSpec(
             File(dir, "build.gradle").writeText(groovyBuildScript!!)
         }
 
+        File(dir, "gradle.properties").writeText(
+            "org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g\n"
+        )
+
         for (otherGradleScript in otherGradleScripts) {
             File(dir, otherGradleScript.key).writeText(otherGradleScript.value)
         }


### PR DESCRIPTION
## Summary
- The scheduled `main` CI run failed in `:plugin:testGradle8` with `java.lang.OutOfMemoryError: Metaspace` inside the inner Gradle TestKit daemon (e.g. https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/26052457759).
- The daemon (Gradle 8.14.3) defaults to `MaxMetaspaceSize=384m`. After ~20 builds within the same TestKit daemon, recipes loaded via `rewriteRun` accumulate classes that aren't unloaded, so the daemon eventually OOMs.
- `GradleProjectSpec` now writes a `gradle.properties` with `org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g` into every generated test project so the TestKit daemon has enough headroom.

## Test plan
- [x] `./gradlew :plugin:testGradle8 --tests "org.openrewrite.gradle.RewriteRunTest"` passes locally