### PR TITLE
Add rewrite-java-next module and bump CI to Java 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 26
       - name: setup-gradle
         uses: gradle/actions/setup-gradle@v5
       - name: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 26
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
 //    "rewriteDependencies"("org.openrewrite:rewrite-docker")
     "rewriteDependencies"("org.openrewrite:rewrite-hcl")
     "rewriteDependencies"("org.openrewrite:rewrite-java")
+    "rewriteDependencies"("org.openrewrite:rewrite-java-next")
     "rewriteDependencies"("org.openrewrite:rewrite-java-25")
     "rewriteDependencies"("org.openrewrite:rewrite-java-21")
     "rewriteDependencies"("org.openrewrite:rewrite-java-17")

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -211,6 +211,7 @@ public class RewritePlugin implements Plugin<Project> {
                 deps.create("org.openrewrite:rewrite-json:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-kotlin:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-java:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-java-next:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-java-25:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-java-21:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-java-17:" + rewriteVersion),


### PR DESCRIPTION
## Summary
- Add `rewrite-java-next` to the plugin's `rewriteDependencies` and to `knownRewriteDependencies` in `RewritePlugin`, alongside the other Java parsers.
- Bump the CI and publish workflows from Java 25 to Java 26 so the new parser can build.

- Relates to https://github.com/openrewrite/rewrite/issues/7554

## Test plan
- [ ] CI build on Java 26 passes