### PR TITLE
Annotate rewrite tasks with @DisableCachingByDefault

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/AbstractRewriteTask.java
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.util.GradleVersion;
+import org.gradle.work.DisableCachingByDefault;
 import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -33,6 +34,7 @@ import java.util.Set;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
+@DisableCachingByDefault(because = "Rewrite tasks act on source files in place and are not safe to cache")
 public abstract class AbstractRewriteTask extends DefaultTask {
     protected @Nullable Provider<Set<File>> resolvedDependencies;
     protected boolean dumpGcActivity;

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDiscoverTask.java
@@ -16,9 +16,11 @@
 package org.openrewrite.gradle;
 
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 
+@DisableCachingByDefault(because = "Rewrite tasks act on source files in place and are not safe to cache")
 public class RewriteDiscoverTask extends AbstractRewriteTask {
 
     @Inject

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteDryRunTask.java
@@ -20,10 +20,12 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 import java.nio.file.Path;
 
+@DisableCachingByDefault(because = "Rewrite tasks act on source files in place and are not safe to cache")
 public class RewriteDryRunTask extends AbstractRewriteTask {
 
     private static final Logger logger = Logging.getLogger(RewriteDryRunTask.class);

--- a/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewriteRunTask.java
@@ -18,9 +18,11 @@ package org.openrewrite.gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 
+@DisableCachingByDefault(because = "Rewrite tasks act on source files in place and are not safe to cache")
 public class RewriteRunTask extends AbstractRewriteTask {
 
     private static final Logger logger = Logging.getLogger(RewriteRunTask.class);


### PR DESCRIPTION
## What's changed

The `build` job on `main` started failing the `:plugin:validatePlugins` task after the Gradle wrapper update to 9.5.1:

```
Plugin validation failed with 4 problems:
  - Error: Type 'org.openrewrite.gradle.AbstractRewriteTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
  - Error: Type 'org.openrewrite.gradle.RewriteDiscoverTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
  - Error: Type 'org.openrewrite.gradle.RewriteDryRunTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
  - Error: Type 'org.openrewrite.gradle.RewriteRunTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
```

Gradle now requires every `Task` type to declare its caching behavior. The rewrite tasks operate on source files in place and are not safe to cache, so they are annotated with `@DisableCachingByDefault`.

## Verification

`./gradlew :plugin:validatePlugins` now passes locally.

Fixes the failing run: https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/26598457449/job/78375518779