### PR TITLE
Resolve the Gradle JavaVersion from declared release/toolchain config

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
@@ -257,6 +257,15 @@ class AndroidProjectParser {
                 logger.warn("Unable to determine Java source or target compatibility versions", e);
             }
         }
+        // Fall back to the JVM running the build when the Android compile options are unset, so the
+        // JavaVersion marker reports a real version rather than -1.
+        String runtimeVersion = System.getProperty("java.specification.version", "");
+        if (sourceCompatibility == null || sourceCompatibility.trim().isEmpty()) {
+            sourceCompatibility = runtimeVersion;
+        }
+        if (targetCompatibility == null || targetCompatibility.trim().isEmpty()) {
+            targetCompatibility = sourceCompatibility;
+        }
         return new JavaVersion(Tree.randomId(),
                 System.getProperty("java.runtime.version"),
                 System.getProperty("java.vm.vendor"),

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/AndroidProjectParser.java
@@ -257,15 +257,6 @@ class AndroidProjectParser {
                 logger.warn("Unable to determine Java source or target compatibility versions", e);
             }
         }
-        // Fall back to the JVM running the build when the Android compile options are unset, so the
-        // JavaVersion marker reports a real version rather than -1.
-        String runtimeVersion = System.getProperty("java.specification.version", "");
-        if (sourceCompatibility == null || sourceCompatibility.trim().isEmpty()) {
-            sourceCompatibility = runtimeVersion;
-        }
-        if (targetCompatibility == null || targetCompatibility.trim().isEmpty()) {
-            targetCompatibility = sourceCompatibility;
-        }
         return new JavaVersion(Tree.randomId(),
                 System.getProperty("java.runtime.version"),
                 System.getProperty("java.vm.vendor"),

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1621,15 +1621,18 @@ public class DefaultProjectParser implements GradleProjectParser {
         }
 
         // sourceCompatibility/targetCompatibility are empty when the build configures the Java version
-        // only through `options.release` or a Java toolchain. Fall back to those, and finally to the JVM
-        // running the build, so the JavaVersion marker reports a real version rather than -1.
+        // only through `options.release` or a Java toolchain. Fall back to whichever the project
+        // declares so the JavaVersion marker reflects the project's configuration. Only versions
+        // declared in the project are reported; nothing is inferred from the JVM running the build.
         if (isBlank(sourceCompatibility) || isBlank(targetCompatibility)) {
-            String resolved = resolveJavaVersion(subproject, javaCompileTask);
-            if (isBlank(sourceCompatibility)) {
-                sourceCompatibility = resolved;
-            }
-            if (isBlank(targetCompatibility)) {
-                targetCompatibility = resolved;
+            String declared = declaredJavaVersion(subproject, javaCompileTask);
+            if (declared != null) {
+                if (isBlank(sourceCompatibility)) {
+                    sourceCompatibility = declared;
+                }
+                if (isBlank(targetCompatibility)) {
+                    targetCompatibility = declared;
+                }
             }
         }
 
@@ -1645,23 +1648,28 @@ public class DefaultProjectParser implements GradleProjectParser {
         return value == null || value.trim().isEmpty();
     }
 
-    private static String resolveJavaVersion(Project subproject, @Nullable JavaCompile javaCompileTask) {
+    /**
+     * The Java version declared by the project through {@code options.release} or a Java toolchain,
+     * or {@code null} when the project declares neither. The JVM running the build is deliberately
+     * not consulted: only versions configured in the project are reported.
+     */
+    private static @Nullable String declaredJavaVersion(Project subproject, @Nullable JavaCompile javaCompileTask) {
         // `options.release` and the Java toolchain APIs are only available on Gradle 6.7+.
-        if (GradleVersion.current().compareTo(GradleVersion.version("6.7")) >= 0) {
-            if (javaCompileTask != null && javaCompileTask.getOptions().getRelease().isPresent()) {
-                return javaCompileTask.getOptions().getRelease().get().toString();
-            }
-            JavaPluginExtension javaExtension = subproject.getExtensions().findByType(JavaPluginExtension.class);
-            if (javaExtension != null) {
-                // getOrNull() reads the declared toolchain without triggering JDK provisioning.
-                JavaLanguageVersion languageVersion = javaExtension.getToolchain().getLanguageVersion().getOrNull();
-                if (languageVersion != null) {
-                    return Integer.toString(languageVersion.asInt());
-                }
+        if (GradleVersion.current().compareTo(GradleVersion.version("6.7")) < 0) {
+            return null;
+        }
+        if (javaCompileTask != null && javaCompileTask.getOptions().getRelease().isPresent()) {
+            return javaCompileTask.getOptions().getRelease().get().toString();
+        }
+        JavaPluginExtension javaExtension = subproject.getExtensions().findByType(JavaPluginExtension.class);
+        if (javaExtension != null) {
+            // getOrNull() reads the declared toolchain without triggering JDK provisioning.
+            JavaLanguageVersion languageVersion = javaExtension.getToolchain().getLanguageVersion().getOrNull();
+            if (languageVersion != null) {
+                return Integer.toString(languageVersion.asInt());
             }
         }
-        // Last resort: the JVM running the build, so the marker is never left blank (which parses to -1).
-        return System.getProperty("java.specification.version", "");
+        return null;
     }
 
     private Charset getSourceFileEncoding(@Nullable CompileOptions compileOptions) {

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.invocation.DefaultGradle;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.util.GradleVersion;
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet;
 import org.jspecify.annotations.Nullable;
@@ -775,7 +776,7 @@ public class DefaultProjectParser implements GradleProjectParser {
             JavaTypeCache javaTypeCache = createTypeCache();
             JavaCompile javaCompileTask = (JavaCompile) subproject.getTasks()
                     .getByName(sourceSet.getCompileJavaTaskName());
-            JavaVersion javaVersion = getJavaVersion(javaCompileTask);
+            JavaVersion javaVersion = getJavaVersion(subproject, javaCompileTask);
 
             Path absoluteBuildDir = subproject.getLayout().getBuildDirectory()
                     .get().getAsFile().toPath().toAbsolutePath().normalize();
@@ -1611,20 +1612,56 @@ public class DefaultProjectParser implements GradleProjectParser {
         })).collect(toList());
     }
 
-    private JavaVersion getJavaVersion(@Nullable JavaCompile javaCompileTask) {
+    private JavaVersion getJavaVersion(Project subproject, @Nullable JavaCompile javaCompileTask) {
         String sourceCompatibility = "";
         String targetCompatibility = "";
         if (javaCompileTask != null) {
             sourceCompatibility = javaCompileTask.getSourceCompatibility();
             targetCompatibility = javaCompileTask.getTargetCompatibility();
         }
+
+        // sourceCompatibility/targetCompatibility are empty when the build configures the Java version
+        // only through `options.release` or a Java toolchain. Fall back to those, and finally to the JVM
+        // running the build, so the JavaVersion marker reports a real version rather than -1.
+        if (isBlank(sourceCompatibility) || isBlank(targetCompatibility)) {
+            String resolved = resolveJavaVersion(subproject, javaCompileTask);
+            if (isBlank(sourceCompatibility)) {
+                sourceCompatibility = resolved;
+            }
+            if (isBlank(targetCompatibility)) {
+                targetCompatibility = resolved;
+            }
+        }
+
         return new JavaVersion(
                 randomId(),
                 System.getProperty("java.runtime.version"),
                 System.getProperty("java.vm.vendor"),
                 sourceCompatibility,
                 targetCompatibility);
+    }
 
+    private static boolean isBlank(@Nullable String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static String resolveJavaVersion(Project subproject, @Nullable JavaCompile javaCompileTask) {
+        // `options.release` and the Java toolchain APIs are only available on Gradle 6.7+.
+        if (GradleVersion.current().compareTo(GradleVersion.version("6.7")) >= 0) {
+            if (javaCompileTask != null && javaCompileTask.getOptions().getRelease().isPresent()) {
+                return javaCompileTask.getOptions().getRelease().get().toString();
+            }
+            JavaPluginExtension javaExtension = subproject.getExtensions().findByType(JavaPluginExtension.class);
+            if (javaExtension != null) {
+                // getOrNull() reads the declared toolchain without triggering JDK provisioning.
+                JavaLanguageVersion languageVersion = javaExtension.getToolchain().getLanguageVersion().getOrNull();
+                if (languageVersion != null) {
+                    return Integer.toString(languageVersion.asInt());
+                }
+            }
+        }
+        // Last resort: the JVM running the build, so the marker is never left blank (which parses to -1).
+        return System.getProperty("java.specification.version", "");
     }
 
     private Charset getSourceFileEncoding(@Nullable CompileOptions compileOptions) {

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -1629,6 +1629,80 @@ class RewriteRunTest : RewritePluginTest {
         )
     }
 
+    @EnabledForGradleRange(min = "7.4")
+    @Test
+    fun `JavaVersion marker reflects the Java toolchain when source compatibility is unset`(
+        @TempDir projectDir: File,
+    ) {
+        // A build that configures the Java version only through a toolchain (no sourceCompatibility)
+        // must still produce a JavaVersion marker with a real major version, not -1. Pin the toolchain
+        // to the JVM running the build so no foreign JDK needs to be provisioned.
+        val major = Runtime.version().feature()
+        gradleProject(projectDir) {
+            rewriteYaml(
+                """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: org.openrewrite.test.AddJavaApplicationProperty
+                displayName: Add a property if has java version
+                description: Add a property if has java version.
+                preconditions:
+                  - org.openrewrite.java.search.HasJavaVersion:
+                      version: $major.X
+                recipeList:
+                  - org.openrewrite.properties.AddProperty:
+                      property: has.java.version
+                      value: true
+            """
+            )
+            buildGradle(
+                """
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                }
+
+                java {
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of($major)
+                    }
+                }
+
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
+                    }
+                }
+
+                rewrite {
+                    activeRecipe("org.openrewrite.test.AddJavaApplicationProperty")
+                }
+            """
+            )
+            sourceSet("main") {
+                java(
+                    """
+                    package org.openrewrite.before;
+
+                    public class HelloWorld {
+                        public static void main(String[] args) {
+                            System.out.println("Hello world");
+                        }
+                    }
+                """
+                )
+                propertiesFile("application.properties", "")
+            }
+        }
+        val result = runGradle(projectDir, taskName())
+        val rewriteRunResult = result.task(":${taskName()}")!!
+        assertThat(rewriteRunResult.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(File(projectDir, "src/main/resources/application.properties").readText())
+            .isEqualTo("has.java.version=true")
+    }
+
     @Test
     fun dependencyInScript(@TempDir projectDir: File) {
         gradleProject(projectDir) {


### PR DESCRIPTION
## What's changed

When parsing a project, the plugin attaches an `org.openrewrite.java.marker.JavaVersion` marker built from `JavaCompile.getSourceCompatibility()` / `getTargetCompatibility()`. A build that configures the Java level **only** through `options.release` or a **Java toolchain** leaves those two strings empty, so the marker was constructed with `""` — which `JavaVersion.getMajorVersion()` parses to `-1`. Downstream that surfaces as a `-1` in `FindJavaVersion`, and makes `HasJavaVersion` / `UsesJavaVersion` preconditions silently fail to match.

When source/target compatibility is blank, the version is now resolved from what the project declares, in order:
1. the compiler's `options.release` flag, then
2. the project's Java toolchain language version — read with `getOrNull()`, so it does **not** trigger JDK provisioning.

Only versions **declared in the project** are reported. The JVM running the build is intentionally never consulted: a project that declares no compatibility, no `release`, and no toolchain keeps an unset marker rather than having a version inferred from the build environment. The `options.release` and toolchain lookups are guarded behind `GradleVersion >= 6.7`.

## Why

Configuring the Java level through a toolchain (`java { toolchain { languageVersion = JavaLanguageVersion.of(N) } }`) is the modern, recommended approach, and it was exactly the configuration that produced a `-1` marker.

## Testing

Added a `RewriteRunTest` case: a project configured with only a Java toolchain (pinned to the JVM running the build so no foreign JDK is provisioned) produces a `JavaVersion` marker that satisfies a `HasJavaVersion` precondition. The test fails without this change because the marker's major version is `-1`.