### PR TITLE
Restrict snapshots repo to org.openrewrite to avoid build-breaking outages

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -39,10 +39,10 @@ repositories {
 
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots")
-            // Only OpenRewrite artifacts come from snapshots; keep third-party (Kotlin, Guava, …)
-            // resolution off this repo so an outage here can't break the whole build.
+            // Only serve snapshot versions from here; keep release resolution (Kotlin, Guava, …)
+            // off this repo so an outage here can't break the whole build.
             mavenContent {
-                includeGroupAndSubgroups("org.openrewrite")
+                snapshotsOnly()
             }
         }
     }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -39,6 +39,11 @@ repositories {
 
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots")
+            // Only OpenRewrite artifacts come from snapshots; keep third-party (Kotlin, Guava, …)
+            // resolution off this repo so an outage here can't break the whole build.
+            mavenContent {
+                includeGroupAndSubgroups("org.openrewrite")
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The build on `main` failed at `:plugin:compileKotlin` ([run 26872200189](https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/26872200189/job/79250075561)):

```
Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:latest.release.
  Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0.
    Could not parse POM .../kotlin-gradle-plugin-2.4.0.pom
      Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugins-bom:2.4.0.
        Could not get resource 'https://central.sonatype.com/repository/maven-snapshots/.../kotlin-gradle-plugins-bom-2.4.0.pom'.
          Connect to central.sonatype.com:443 ... failed: Connect timed out
```

## Root cause

The OpenRewrite snapshots repo (`central.sonatype.com/repository/maven-snapshots`) was declared **before** Maven Central with **no content filter**, so Gradle queried *every* dependency against it first. The build had been green until Kotlin `2.4.0` became `latest.release`; resolving `kotlin-gradle-plugin:2.4.0`'s parent POM required `kotlin-gradle-plugins-bom:2.4.0`, which Gradle attempted against the snapshots repo. A connect timeout there caused Gradle to disable the repository and cascade-fail the whole resolution.

## Fix

Restrict the snapshots repo to the `org.openrewrite` group (and subgroups — the only artifacts that actually need snapshots), so third-party resolution (Kotlin, Guava, JUnit, …) goes straight to Maven Central / the plugin portal and an outage of the snapshots repo can no longer break the build.

Verified locally: `./gradlew :plugin:dependencies --configuration compileClasspath` and `:plugin:compileKotlin` both succeed; `kotlin-gradle-plugins-bom:2.4.0` now resolves from Maven Central.