### PR TITLE
Use Paths.get instead of Path.of in DefaultProjectParserIsExcludedTest

### DIFF
--- a/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/isolated/DefaultProjectParserIsExcludedTest.java
@@ -25,6 +25,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.Collection;
 
 import static java.util.Collections.emptyList;
@@ -52,7 +53,7 @@ class DefaultProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Path.of("generated.txt")))
+            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Paths.get("generated.txt")))
                     .as("untracked gitignored file should be excluded")
                     .isTrue();
         }
@@ -71,7 +72,7 @@ class DefaultProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Path.of("tracked-ignored.txt")))
+            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Paths.get("tracked-ignored.txt")))
                     .as("tracked gitignored file should NOT be excluded")
                     .isFalse();
         }
@@ -88,7 +89,7 @@ class DefaultProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("initial").call();
 
-            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Path.of("build/output.txt")))
+            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Paths.get("build/output.txt")))
                     .as("untracked file in gitignored directory should be excluded")
                     .isTrue();
         }
@@ -107,7 +108,7 @@ class DefaultProjectParserIsExcludedTest {
             git.add().addFilepattern(".gitignore").call();
             git.commit().setMessage("add gitignore").call();
 
-            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Path.of("build/output.txt")))
+            assertThat(DefaultProjectParser.isExcluded(repo, emptyList(), Paths.get("build/output.txt")))
                     .as("tracked file in gitignored directory should NOT be excluded")
                     .isFalse();
         }
@@ -118,7 +119,7 @@ class DefaultProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(DefaultProjectParser.isExcluded(null, matchers, Path.of("config/secret.properties")))
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("config/secret.properties")))
                 .as("path matching exclusion pattern should be excluded")
                 .isTrue();
     }
@@ -128,7 +129,7 @@ class DefaultProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/secret.properties"));
 
-        assertThat(DefaultProjectParser.isExcluded(null, matchers, Path.of("config/application.properties")))
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("config/application.properties")))
                 .as("path not matching exclusion pattern should not be excluded")
                 .isFalse();
     }
@@ -140,7 +141,7 @@ class DefaultProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
 
-        assertThat(DefaultProjectParser.isExcluded(null, matchers, Path.of("build.gradle")))
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("build.gradle")))
                 .as("root-level file should match **/build.gradle via leading-slash prefixing")
                 .isTrue();
     }
@@ -152,7 +153,7 @@ class DefaultProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
 
-        assertThat(DefaultProjectParser.isExcluded(null, matchers, Path.of("/build.gradle")))
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("/build.gradle")))
                 .as("root-level file with leading slash should match **/build.gradle directly")
                 .isTrue();
     }
@@ -163,7 +164,7 @@ class DefaultProjectParserIsExcludedTest {
         Collection<PathMatcher> matchers = singletonList(
                 FileSystems.getDefault().getPathMatcher("glob:**/build.gradle"));
 
-        assertThat(DefaultProjectParser.isExcluded(null, matchers, Path.of("module/build.gradle")))
+        assertThat(DefaultProjectParser.isExcluded(null, matchers, Paths.get("module/build.gradle")))
                 .as("subdirectory file should match **/build.gradle directly")
                 .isTrue();
     }


### PR DESCRIPTION
`DefaultProjectParserIsExcludedTest` failed to compile in CI:

```
error: cannot find symbol
    DefaultProjectParser.isExcluded(repo, emptyList(), Path.of("tracked-ignored.txt"))
  symbol:   method of(String)
  location: interface Path
```

The plugin configures `options.release.set(8)` for all `JavaCompile` tasks, including `compileTestJava`. `Path.of(String)` was only introduced in Java 11, so it does not resolve against the Java 8 API surface. This test was the first to use the Java 11+ API.

Replaces the nine `Path.of(...)` calls with `Paths.get(...)`, which returns the same `java.nio.file.Path` and is available on Java 8. Behavior of the tests is unchanged.

Validated locally with JDK 21: `./gradlew :plugin:test --tests "*DefaultProjectParserIsExcludedTest*"` passes (9 tests).