### PR TITLE
Set Develocity `projectId` to "openrewrite"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 develocity {
     val isCiServer = System.getenv("CI")?.equals("true") ?: false
     server = "https://community.develocity.cloud/"
+    projectId = "openrewrite"
     val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
     val authenticated = !accessKey.isNullOrBlank()
     buildCache {


### PR DESCRIPTION
As part of the Develocity server migration, each project's `develocity` configuration must declare a `projectId` so build scans are associated with the correct project on the new server.

- This sets `projectId = "openrewrite"` in the `develocity {}` block of `settings.gradle.kts`, produced by the new [`org.openrewrite.gradle.SetDevelocityProjectId`](https://github.com/openrewrite/rewrite/pull/8311) recipe.