### PR TITLE
Reload recipe classes when a classpath entry changed

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/DelegatingProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/DelegatingProjectParser.java
@@ -19,24 +19,33 @@ import org.gradle.api.Project;
 import org.gradle.internal.service.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
 public class DelegatingProjectParser implements GradleProjectParser {
+    private static final AtomicLong UNREADABLE_CLASSPATH_ENTRIES = new AtomicLong();
+
     @Nullable
-    protected static List<URL> rewriteClasspath;
+    protected static List<String> rewriteClasspathFingerprint;
     @Nullable
     protected static RewriteClassLoader rewriteClassLoader;
     protected final GradleProjectParser gpp;
@@ -61,15 +70,16 @@ public class DelegatingProjectParser implements GradleProjectParser {
             classpathUrls.add(currentJar);
 
             ClassLoader pluginClassLoader = getPluginClassLoader(project);
+            List<String> classpathFingerprint = fingerprint(classpathUrls);
 
             if (rewriteClassLoader == null ||
-                    !classpathUrls.equals(rewriteClasspath) ||
+                    !classpathFingerprint.equals(rewriteClasspathFingerprint) ||
                     rewriteClassLoader.getPluginClassLoader() != pluginClassLoader) {
                 if (rewriteClassLoader != null) {
-                    rewriteClassLoader.close();
+                    discard(rewriteClassLoader);
                 }
                 rewriteClassLoader = new RewriteClassLoader(classpathUrls, pluginClassLoader);
-                rewriteClasspath = classpathUrls;
+                rewriteClasspathFingerprint = classpathFingerprint;
             }
 
             Class<?> gppClass = Class.forName("org.openrewrite.gradle.isolated.DefaultProjectParser", true, rewriteClassLoader);
@@ -132,6 +142,73 @@ public class DelegatingProjectParser implements GradleProjectParser {
             gpp.shutdownRewrite();
             return null;
         });
+    }
+
+    private static void discard(RewriteClassLoader classLoader) throws IOException {
+        shutdownJGitWorkQueue(classLoader);
+        classLoader.close();
+    }
+
+    /**
+     * JGit keeps a daemon thread around per class loader that initialized it, and that thread references the
+     * class loader that created it. Without shutting it down every replaced class loader, and all the recipe
+     * classes it loaded, would be retained in metaspace for as long as the Gradle daemon lives.
+     */
+    private static void shutdownJGitWorkQueue(ClassLoader classLoader) {
+        try {
+            Class<?> workQueue = Class.forName("org.openrewrite.jgit.lib.internal.WorkQueue", true, classLoader);
+            ((ExecutorService) workQueue.getMethod("getExecutor").invoke(null)).shutdownNow();
+        } catch (ReflectiveOperationException | ClassCastException | LinkageError ignored) {
+            // Not all versions of rewrite bundle JGit, in which case there is no work queue to shut down
+        }
+    }
+
+    /**
+     * Recipe jars built by the project itself are replaced in place, keeping the same location on the classpath.
+     * Comparing locations alone would then reuse a {@link RewriteClassLoader} holding the previous recipe classes
+     * for as long as the Gradle daemon lives, so compare the contents of each classpath entry as well.
+     */
+    static List<String> fingerprint(Collection<URL> classpath) {
+        return classpath.stream()
+                .map(DelegatingProjectParser::fingerprint)
+                .sorted()
+                .collect(toList());
+    }
+
+    private static String fingerprint(URL classpathEntry) {
+        if (!"file".equals(classpathEntry.getProtocol())) {
+            return classpathEntry + "|" + UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
+        }
+        try {
+            return classpathEntry + "|" + fingerprint(Paths.get(classpathEntry.toURI()));
+        } catch (URISyntaxException e) {
+            return classpathEntry + "|" + UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
+        }
+    }
+
+    private static String fingerprint(Path classpathEntry) {
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(classpathEntry, BasicFileAttributes.class);
+            if (!attributes.isDirectory()) {
+                return attributes.size() + "|" + attributes.lastModifiedTime().toMillis();
+            }
+            try (Stream<Path> contents = Files.walk(classpathEntry)) {
+                return "directory|" + contents.filter(Files::isRegularFile)
+                        .mapToLong(DelegatingProjectParser::fingerprintHash)
+                        .sum();
+            }
+        } catch (IOException e) {
+            return String.valueOf(UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet());
+        }
+    }
+
+    private static long fingerprintHash(Path file) {
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+            return 31L * file.hashCode() + 31L * attributes.size() + attributes.lastModifiedTime().toMillis();
+        } catch (IOException e) {
+            return UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
+        }
     }
 
     protected URL jarContainingResource(String resourcePath) {

--- a/plugin/src/main/java/org/openrewrite/gradle/DelegatingProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/DelegatingProjectParser.java
@@ -23,27 +23,25 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
+import static java.util.Collections.sort;
 import static java.util.stream.Collectors.toList;
 
 public class DelegatingProjectParser implements GradleProjectParser {
-    private static final AtomicLong UNREADABLE_CLASSPATH_ENTRIES = new AtomicLong();
-
     @Nullable
     protected static List<String> rewriteClasspathFingerprint;
     @Nullable
@@ -69,10 +67,14 @@ public class DelegatingProjectParser implements GradleProjectParser {
                     .toString());
             classpathUrls.add(currentJar);
 
+            List<Path> classpathEntries = new ArrayList<>(classpath);
+            classpathEntries.add(Paths.get(currentJar.toURI()));
+
             ClassLoader pluginClassLoader = getPluginClassLoader(project);
-            List<String> classpathFingerprint = fingerprint(classpathUrls);
+            List<String> classpathFingerprint = fingerprint(classpathEntries);
 
             if (rewriteClassLoader == null ||
+                    classpathFingerprint == null ||
                     !classpathFingerprint.equals(rewriteClasspathFingerprint) ||
                     rewriteClassLoader.getPluginClassLoader() != pluginClassLoader) {
                 if (rewriteClassLoader != null) {
@@ -145,69 +147,57 @@ public class DelegatingProjectParser implements GradleProjectParser {
     }
 
     private static void discard(RewriteClassLoader classLoader) throws IOException {
-        shutdownJGitWorkQueue(classLoader);
-        classLoader.close();
-    }
-
-    /**
-     * JGit keeps a daemon thread around per class loader that initialized it, and that thread references the
-     * class loader that created it. Without shutting it down every replaced class loader, and all the recipe
-     * classes it loaded, would be retained in metaspace for as long as the Gradle daemon lives.
-     */
-    private static void shutdownJGitWorkQueue(ClassLoader classLoader) {
         try {
-            Class<?> workQueue = Class.forName("org.openrewrite.jgit.lib.internal.WorkQueue", true, classLoader);
-            ((ExecutorService) workQueue.getMethod("getExecutor").invoke(null)).shutdownNow();
-        } catch (ReflectiveOperationException | ClassCastException | LinkageError ignored) {
+            Class.forName("org.openrewrite.gradle.isolated.DefaultProjectParser", true, classLoader)
+                    .getMethod("shutdownJGitWorkQueue")
+                    .invoke(null);
+        } catch (ReflectiveOperationException | LinkageError ignored) {
             // Not all versions of rewrite bundle JGit, in which case there is no work queue to shut down
         }
+        classLoader.close();
     }
 
     /**
      * Recipe jars built by the project itself are replaced in place, keeping the same location on the classpath.
      * Comparing locations alone would then reuse a {@link RewriteClassLoader} holding the previous recipe classes
      * for as long as the Gradle daemon lives, so compare the contents of each classpath entry as well.
+     *
+     * @return a fingerprint per classpath entry, or {@code null} if any entry could not be read
      */
-    static List<String> fingerprint(Collection<URL> classpath) {
-        return classpath.stream()
-                .map(DelegatingProjectParser::fingerprint)
-                .sorted()
-                .collect(toList());
-    }
-
-    private static String fingerprint(URL classpathEntry) {
-        if (!"file".equals(classpathEntry.getProtocol())) {
-            return classpathEntry + "|" + UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
-        }
-        try {
-            return classpathEntry + "|" + fingerprint(Paths.get(classpathEntry.toURI()));
-        } catch (URISyntaxException e) {
-            return classpathEntry + "|" + UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
-        }
-    }
-
-    private static String fingerprint(Path classpathEntry) {
-        try {
-            BasicFileAttributes attributes = Files.readAttributes(classpathEntry, BasicFileAttributes.class);
-            if (!attributes.isDirectory()) {
-                return attributes.size() + "|" + attributes.lastModifiedTime().toMillis();
+    static @Nullable List<String> fingerprint(Collection<Path> classpath) {
+        List<String> fingerprints = new ArrayList<>(classpath.size());
+        for (Path classpathEntry : classpath) {
+            try {
+                fingerprints.add(fingerprint(classpathEntry));
+            } catch (IOException e) {
+                return null;
             }
-            try (Stream<Path> contents = Files.walk(classpathEntry)) {
-                return "directory|" + contents.filter(Files::isRegularFile)
-                        .mapToLong(DelegatingProjectParser::fingerprintHash)
-                        .sum();
-            }
-        } catch (IOException e) {
-            return String.valueOf(UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet());
         }
+        sort(fingerprints);
+        return fingerprints;
     }
 
-    private static long fingerprintHash(Path file) {
-        try {
-            BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
-            return 31L * file.hashCode() + 31L * attributes.size() + attributes.lastModifiedTime().toMillis();
-        } catch (IOException e) {
-            return UNREADABLE_CLASSPATH_ENTRIES.incrementAndGet();
+    private static String fingerprint(Path classpathEntry) throws IOException {
+        BasicFileAttributes attributes = Files.readAttributes(classpathEntry, BasicFileAttributes.class);
+        if (!attributes.isDirectory()) {
+            return classpathEntry + "|" + stamp(classpathEntry, attributes);
+        }
+        DirectoryStamp directoryStamp = new DirectoryStamp();
+        Files.walkFileTree(classpathEntry, directoryStamp);
+        return classpathEntry + "|" + directoryStamp.stamp;
+    }
+
+    private static long stamp(Path file, BasicFileAttributes attributes) {
+        return 31L * (31L * file.hashCode() + attributes.size()) + attributes.lastModifiedTime().toMillis();
+    }
+
+    private static class DirectoryStamp extends SimpleFileVisitor<Path> {
+        private long stamp;
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+            stamp += stamp(file, attributes);
+            return FileVisitResult.CONTINUE;
         }
     }
 

--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -68,6 +68,7 @@ import org.openrewrite.jgit.api.Git;
 import org.openrewrite.jgit.dircache.DirCache;
 import org.openrewrite.jgit.lib.ObjectId;
 import org.openrewrite.jgit.lib.Repository;
+import org.openrewrite.jgit.lib.internal.WorkQueue;
 import org.openrewrite.jgit.revwalk.RevCommit;
 import org.openrewrite.jgit.revwalk.RevWalk;
 import org.openrewrite.jgit.treewalk.TreeWalk;
@@ -1499,6 +1500,19 @@ public class DefaultProjectParser implements GradleProjectParser {
         if (repository != null) {
             repository.close();
         }
+    }
+
+    /**
+     * JGit keeps a daemon thread around per class loader that initialized it, and that thread references the
+     * class loader that created it. Without shutting it down every replaced class loader, and all the recipe
+     * classes it loaded, would be retained in metaspace for as long as the Gradle daemon lives.
+     * <p>
+     * Deliberately not part of {@link #shutdownRewrite()}, as the executor is created once per class loader and
+     * never recreated; it may only be shut down when the class loader itself is discarded.
+     */
+    @SuppressWarnings("unused") // Called reflectively by DelegatingProjectParser when it discards a class loader
+    public static void shutdownJGitWorkQueue() {
+        WorkQueue.getExecutor().shutdownNow();
     }
 
     private static synchronized MavenPomCache getPomCache(@Nullable String pomCacheDirectory) {

--- a/plugin/src/test/java/org/openrewrite/gradle/DelegatingProjectParserTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/DelegatingProjectParserTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.Issue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.DelegatingProjectParser.fingerprint;
+
+@Issue("https://github.com/openrewrite/rewrite-gradle-plugin/issues/453")
+class DelegatingProjectParserTest {
+
+    @Test
+    void unchangedClasspathHasEqualFingerprints(@TempDir Path tempDir) throws IOException {
+        Path jar = write(tempDir.resolve("recipes.jar"), "first");
+
+        assertThat(fingerprint(urls(jar))).isEqualTo(fingerprint(urls(jar)));
+    }
+
+    @Test
+    void orderDoesNotAffectFingerprint(@TempDir Path tempDir) throws IOException {
+        Path first = write(tempDir.resolve("first.jar"), "first");
+        Path second = write(tempDir.resolve("second.jar"), "second");
+
+        assertThat(fingerprint(urls(first, second))).isEqualTo(fingerprint(urls(second, first)));
+    }
+
+    @Test
+    void replacedJarChangesFingerprint(@TempDir Path tempDir) throws IOException {
+        Path jar = write(tempDir.resolve("recipes.jar"), "first");
+        List<String> before = fingerprint(urls(jar));
+
+        write(jar, "second");
+
+        assertThat(fingerprint(urls(jar))).isNotEqualTo(before);
+    }
+
+    @Test
+    void rebuiltJarOfEqualSizeChangesFingerprint(@TempDir Path tempDir) throws IOException {
+        Path jar = write(tempDir.resolve("recipes.jar"), "first");
+        List<String> before = fingerprint(urls(jar));
+
+        touch(jar);
+
+        assertThat(fingerprint(urls(jar))).isNotEqualTo(before);
+    }
+
+    @Test
+    void changedFileWithinDirectoryChangesFingerprint(@TempDir Path tempDir) throws IOException {
+        Path classes = Files.createDirectories(tempDir.resolve("classes/org/example"));
+        write(classes.resolve("Recipe.class"), "first");
+        List<String> before = fingerprint(urls(tempDir.resolve("classes")));
+
+        touch(write(classes.resolve("Recipe.class"), "second"));
+
+        assertThat(fingerprint(urls(tempDir.resolve("classes")))).isNotEqualTo(before);
+    }
+
+    @Test
+    void fileAddedToDirectoryChangesFingerprint(@TempDir Path tempDir) throws IOException {
+        Path classes = Files.createDirectories(tempDir.resolve("classes/org/example"));
+        write(classes.resolve("Recipe.class"), "first");
+        List<String> before = fingerprint(urls(tempDir.resolve("classes")));
+
+        write(classes.resolve("OtherRecipe.class"), "first");
+
+        assertThat(fingerprint(urls(tempDir.resolve("classes")))).isNotEqualTo(before);
+    }
+
+    private static Path write(Path file, String content) throws IOException {
+        return Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static Path touch(Path file) throws IOException {
+        FileTime lastModified = Files.getLastModifiedTime(file);
+        return Files.setLastModifiedTime(file, FileTime.fromMillis(lastModified.toMillis() + 1_000));
+    }
+
+    private static List<URL> urls(Path... paths) {
+        return Arrays.stream(paths)
+                .map(path -> {
+                    try {
+                        return path.toUri().toURL();
+                    } catch (MalformedURLException e) {
+                        throw new IllegalStateException(e);
+                    }
+                })
+                .collect(toList());
+    }
+}

--- a/plugin/src/test/java/org/openrewrite/gradle/DelegatingProjectParserTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/DelegatingProjectParserTest.java
@@ -20,16 +20,14 @@ import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.Issue;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
-import java.util.Arrays;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.DelegatingProjectParser.fingerprint;
 
@@ -40,7 +38,7 @@ class DelegatingProjectParserTest {
     void unchangedClasspathHasEqualFingerprints(@TempDir Path tempDir) throws IOException {
         Path jar = write(tempDir.resolve("recipes.jar"), "first");
 
-        assertThat(fingerprint(urls(jar))).isEqualTo(fingerprint(urls(jar)));
+        assertThat(fingerprint(singletonList(jar))).isEqualTo(fingerprint(singletonList(jar)));
     }
 
     @Test
@@ -48,49 +46,54 @@ class DelegatingProjectParserTest {
         Path first = write(tempDir.resolve("first.jar"), "first");
         Path second = write(tempDir.resolve("second.jar"), "second");
 
-        assertThat(fingerprint(urls(first, second))).isEqualTo(fingerprint(urls(second, first)));
+        assertThat(fingerprint(asList(first, second))).isEqualTo(fingerprint(asList(second, first)));
+    }
+
+    @Test
+    void missingClasspathEntryHasNoFingerprint(@TempDir Path tempDir) {
+        assertThat(fingerprint(singletonList(tempDir.resolve("missing.jar")))).isNull();
     }
 
     @Test
     void replacedJarChangesFingerprint(@TempDir Path tempDir) throws IOException {
         Path jar = write(tempDir.resolve("recipes.jar"), "first");
-        List<String> before = fingerprint(urls(jar));
+        List<String> before = fingerprint(singletonList(jar));
 
         write(jar, "second");
 
-        assertThat(fingerprint(urls(jar))).isNotEqualTo(before);
+        assertThat(fingerprint(singletonList(jar))).isNotEqualTo(before);
     }
 
     @Test
     void rebuiltJarOfEqualSizeChangesFingerprint(@TempDir Path tempDir) throws IOException {
         Path jar = write(tempDir.resolve("recipes.jar"), "first");
-        List<String> before = fingerprint(urls(jar));
+        List<String> before = fingerprint(singletonList(jar));
 
         touch(jar);
 
-        assertThat(fingerprint(urls(jar))).isNotEqualTo(before);
+        assertThat(fingerprint(singletonList(jar))).isNotEqualTo(before);
     }
 
     @Test
     void changedFileWithinDirectoryChangesFingerprint(@TempDir Path tempDir) throws IOException {
         Path classes = Files.createDirectories(tempDir.resolve("classes/org/example"));
         write(classes.resolve("Recipe.class"), "first");
-        List<String> before = fingerprint(urls(tempDir.resolve("classes")));
+        List<String> before = fingerprint(singletonList(tempDir.resolve("classes")));
 
-        touch(write(classes.resolve("Recipe.class"), "second"));
+        touch(classes.resolve("Recipe.class"));
 
-        assertThat(fingerprint(urls(tempDir.resolve("classes")))).isNotEqualTo(before);
+        assertThat(fingerprint(singletonList(tempDir.resolve("classes")))).isNotEqualTo(before);
     }
 
     @Test
     void fileAddedToDirectoryChangesFingerprint(@TempDir Path tempDir) throws IOException {
         Path classes = Files.createDirectories(tempDir.resolve("classes/org/example"));
         write(classes.resolve("Recipe.class"), "first");
-        List<String> before = fingerprint(urls(tempDir.resolve("classes")));
+        List<String> before = fingerprint(singletonList(tempDir.resolve("classes")));
 
         write(classes.resolve("OtherRecipe.class"), "first");
 
-        assertThat(fingerprint(urls(tempDir.resolve("classes")))).isNotEqualTo(before);
+        assertThat(fingerprint(singletonList(tempDir.resolve("classes")))).isNotEqualTo(before);
     }
 
     private static Path write(Path file, String content) throws IOException {
@@ -100,17 +103,5 @@ class DelegatingProjectParserTest {
     private static Path touch(Path file) throws IOException {
         FileTime lastModified = Files.getLastModifiedTime(file);
         return Files.setLastModifiedTime(file, FileTime.fromMillis(lastModified.toMillis() + 1_000));
-    }
-
-    private static List<URL> urls(Path... paths) {
-        return Arrays.stream(paths)
-                .map(path -> {
-                    try {
-                        return path.toUri().toURL();
-                    } catch (MalformedURLException e) {
-                        throw new IllegalStateException(e);
-                    }
-                })
-                .collect(toList());
     }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
+import org.openrewrite.gradle.fixtures.GradleFixtures
 import java.io.File
 
 class RewriteDiscoverTest : RewritePluginTest {
@@ -65,4 +66,70 @@ class RewriteDiscoverTest : RewritePluginTest {
 
         assertThat(result.output).contains("Configured with 2 active recipes and 1 active styles.")
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-gradle-plugin/issues/453")
+    @Test
+    fun `rewriteDiscover picks up recipes rebuilt within the same daemon`(
+        @TempDir projectDir: File
+    ) {
+        gradleProject(projectDir) {
+            buildGradle("""
+                plugins {
+                    id("java")
+                    id("org.openrewrite.rewrite")
+                }
+
+                ${GradleFixtures.REPOSITORIES}
+
+                dependencies {
+                    rewrite(project(":recipes"))
+                }
+            """)
+
+            subproject("recipes") {
+                buildGradle("""
+                    plugins {
+                        id("java")
+                    }
+
+                    ${GradleFixtures.REPOSITORIES}
+
+                    dependencies {
+                        implementation("org.openrewrite:rewrite-core:latest.release")
+                    }
+                """)
+
+                sourceSet("main") {
+                    java(recipe("FirstRecipe"))
+                }
+            }
+        }
+
+        assertThat(runGradle(projectDir, taskName()).output).contains("org.example.FirstRecipe")
+
+        val recipeSources = File(projectDir, "recipes/src/main/java/org/example")
+        assertThat(File(recipeSources, "FirstRecipe.java").delete()).isTrue()
+        File(recipeSources, "SecondRecipe.java").writeText(recipe("SecondRecipe"))
+
+        assertThat(runGradle(projectDir, taskName()).output).contains("org.example.SecondRecipe")
+    }
+
+    //language=java
+    private fun recipe(className: String) = """
+        package org.example;
+
+        import org.openrewrite.Recipe;
+
+        public class $className extends Recipe {
+            @Override
+            public String getDisplayName() {
+                return "$className";
+            }
+
+            @Override
+            public String getDescription() {
+                return "$className.";
+            }
+        }
+    """.trimIndent()
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
@@ -73,14 +73,7 @@ class RewriteDiscoverTest : RewritePluginTest {
         @TempDir projectDir: File
     ) {
         gradleProject(projectDir) {
-            buildGradle("""
-                plugins {
-                    id("java")
-                    id("org.openrewrite.rewrite")
-                }
-
-                ${GradleFixtures.REPOSITORIES}
-
+            buildGradle(GradleFixtures.REWRITE_BUILD_GRADLE + """
                 dependencies {
                     rewrite(project(":recipes"))
                 }


### PR DESCRIPTION
- Fixes #453

### The problem

`DelegatingProjectParser` caches the `RewriteClassLoader` in a static field, so it survives across builds in the Gradle daemon, and only replaced it when the *set of classpath locations* changed:

```java
if (rewriteClassLoader == null ||
        !classpathUrls.equals(rewriteClasspath) ||
        rewriteClassLoader.getPluginClassLoader() != pluginClassLoader) {
```

Recipes built by the project itself (an included build, a `project(":recipes")` dependency, or `publishToMavenLocal`) keep the same location when rebuilt, so the URLs compare equal and the previous recipe classes keep being used until the daemon is stopped. @freya022's diagnosis in the issue was spot on.

### The fix

Compare the size and last modified time of each classpath entry as well; for directory entries that's rolled up over the files they contain. Two `stat` calls per classpath entry is nothing next to parsing a project, and published artifacts in the module cache never change, so ordinary users see no extra class loading.

### Metaspace

Replacing the class loader more often surfaced that replaced loaders are never unloaded. One cause is in this repo: JGit starts a `JGit-WorkQueue` daemon thread per class loader that initializes it, and the thread's pool references the loader that created it. Without the shutdown added here, thread count grows one per replacement and every ~33 MB loader is pinned forever; with Gradle's default 384 MB metaspace the daemon dies after a handful of recipe edits.

Shutting the work queue down keeps the thread count at 1, but measuring across 8 edit/run cycles the loaders are still retained (~40 MB per cycle, `VM.classloader_stats` shows 8 live `RewriteClassLoader`s that survive a forced full GC). So at least one more retainer lives outside this repo — most likely a `ThreadLocal` or static registered from rewrite on a daemon thread. That retention is pre-existing: any change to the `rewrite` configuration already replaced the loader. This PR makes it easier to hit while developing recipes, so it is worth a follow-up on the rewrite side. Until then, recipe authors seeing `Metaspace` errors can raise `org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g`.

### Verification

- `DelegatingProjectParserTest` covers the fingerprint: unchanged classpath, order independence, replaced jar, same-size rebuild, and changed/added files inside a directory entry.
- `RewriteDiscoverTest` builds a project with a recipe subproject, runs `rewriteDiscover`, swaps the recipe source, and runs again in the same TestKit daemon. It fails on `main` and passes here.
- Ran @freya022's scenario (included build + dependency substitution) against a locally published plugin: before, `rewriteRun` kept applying the first version of the recipe across daemon-reusing builds; after, every edit takes effect.