### PR TITLE
Warn when recipe artifacts resolve from Maven Central

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/CodeGenomeProjectWarning.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/CodeGenomeProjectWarning.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * New OpenRewrite and Moderne recipe releases are published to the Code Genome Project rather than to Maven Central.
+ * Releases already on Maven Central remain there, so a build that resolves recipes with a dynamic version against
+ * Maven Central keeps succeeding while silently pinning itself to the last release published there.
+ * <p>
+ * This detects that situation so the plugin can point the user at the Code Genome Project. It is informational only.
+ */
+final class CodeGenomeProjectWarning {
+
+    static final String CREDENTIALS_DOCS = "https://codegenomeproject.org/token";
+
+    private CodeGenomeProjectWarning() {
+    }
+
+    /**
+     * @param repositoryUrls      the repositories recipe artifacts resolve against
+     * @param requestedRecipeDependencies dependencies of the {@code rewrite} configuration, as {@code group:name:version}
+     * @return a warning to log, or {@code null} when recipes cannot be silently stale
+     */
+    static @Nullable String warningFor(Collection<URI> repositoryUrls, Collection<String> requestedRecipeDependencies) {
+        if (!resolvesFromMavenCentralOnly(repositoryUrls)) {
+            return null;
+        }
+        Set<String> stale = new LinkedHashSet<>();
+        for (String dependency : requestedRecipeDependencies) {
+            String[] coordinates = dependency.split(":", 3);
+            if (coordinates.length == 3 && isRecipeArtifact(coordinates[0]) && isDynamicVersion(coordinates[2])) {
+                stale.add(dependency);
+            }
+        }
+        if (stale.isEmpty()) {
+            return null;
+        }
+
+        StringBuilder warning = new StringBuilder("These recipe artifacts resolve from Maven Central, which no longer receives new recipe releases:");
+        for (String dependency : stale) {
+            warning.append("\n    ").append(dependency);
+        }
+        return warning
+                .append("\nNewer recipe versions are published to the Code Genome Project; configure it in your repositories to stop resolving stale recipes.")
+                .append("\nSee ").append(CREDENTIALS_DOCS).append(" for credentials and repository configuration.")
+                .toString();
+    }
+
+    /**
+     * Maven Central being absent means recipes come from somewhere that may well be current, such as the Code Genome
+     * Project itself or an internal mirror. An unknown repository set, as when repositories are declared in settings
+     * rather than in the project, is treated the same way so that the warning stays quiet unless staleness is likely.
+     */
+    private static boolean resolvesFromMavenCentralOnly(Collection<URI> repositoryUrls) {
+        boolean mavenCentral = false;
+        for (URI repositoryUrl : repositoryUrls) {
+            String host = repositoryUrl.getHost();
+            if (host == null) {
+                continue;
+            }
+            if (host.contains("codegenome")) {
+                return false;
+            }
+            mavenCentral |= "repo.maven.apache.org".equals(host) || "repo1.maven.org".equals(host) || "repo2.maven.org".equals(host);
+        }
+        return mavenCentral;
+    }
+
+    private static boolean isRecipeArtifact(String group) {
+        return "org.openrewrite".equals(group) || group.startsWith("org.openrewrite.") ||
+               "io.moderne".equals(group) || group.startsWith("io.moderne.");
+    }
+
+    /**
+     * A version the user deliberately pinned is left alone; only a version that asks for "whatever is newest" can
+     * quietly resolve to the final Maven Central release.
+     */
+    private static boolean isDynamicVersion(String version) {
+        return version.startsWith("latest.") || version.endsWith("+") ||
+               version.startsWith("[") || version.startsWith("(") || version.startsWith("]");
+    }
+}

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -21,6 +21,8 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.attributes.*;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.model.ObjectFactory;
@@ -36,6 +38,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.*;
 
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
@@ -166,6 +169,8 @@ public class RewritePlugin implements Plugin<Project> {
 
     private Set<File> getResolvedDependencies(Project project, RewriteExtension extension, Configuration rewriteConf) {
         if (resolvedDependencies == null) {
+            warnOnStaleRecipeArtifacts(project, rewriteConf);
+
             // Avoid Stream.concat here pending https://github.com/gradle/gradle/issues/33152
             List<Dependency> dependencies = new ArrayList<>();
             dependencies.addAll(knownRewriteDependencies(extension, project.getDependencies()));
@@ -198,6 +203,23 @@ public class RewritePlugin implements Plugin<Project> {
             resolvedDependencies = detachedConf.resolve();
         }
         return resolvedDependencies;
+    }
+
+    private static void warnOnStaleRecipeArtifacts(Project project, Configuration rewriteConf) {
+        List<URI> repositoryUrls = new ArrayList<>();
+        for (ArtifactRepository repository : project.getRepositories()) {
+            if (repository instanceof MavenArtifactRepository) {
+                repositoryUrls.add(((MavenArtifactRepository) repository).getUrl());
+            }
+        }
+        List<String> requestedRecipeDependencies = new ArrayList<>();
+        for (Dependency dependency : rewriteConf.getDependencies()) {
+            requestedRecipeDependencies.add(dependency.getGroup() + ":" + dependency.getName() + ":" + dependency.getVersion());
+        }
+        String warning = CodeGenomeProjectWarning.warningFor(repositoryUrls, requestedRecipeDependencies);
+        if (warning != null) {
+            project.getLogger().warn(warning);
+        }
     }
 
     private static Collection<Dependency> knownRewriteDependencies(RewriteExtension extension, DependencyHandler deps) {

--- a/plugin/src/test/java/org/openrewrite/gradle/CodeGenomeProjectWarningTest.java
+++ b/plugin/src/test/java/org/openrewrite/gradle/CodeGenomeProjectWarningTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.Issue;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Issue("https://github.com/openrewrite/rewrite-gradle-plugin/issues/458")
+class CodeGenomeProjectWarningTest {
+
+    private static final Collection<URI> MAVEN_CENTRAL = singletonList(URI.create("https://repo.maven.apache.org/maven2/"));
+
+    @ParameterizedTest
+    @ValueSource(strings = {"latest.release", "latest.integration", "6.+", "+", "[6.0,7.0)"})
+    void warnOnDynamicVersionsResolvedFromMavenCentral(String version) {
+        String warning = CodeGenomeProjectWarning.warningFor(
+          MAVEN_CENTRAL, singletonList("org.openrewrite.recipe:rewrite-spring:" + version));
+
+        assertThat(warning)
+          .contains("org.openrewrite.recipe:rewrite-spring:" + version)
+          .contains(CodeGenomeProjectWarning.CREDENTIALS_DOCS);
+    }
+
+    @Test
+    void warnOnModerneRecipeArtifacts() {
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          MAVEN_CENTRAL, singletonList("io.moderne.recipe:rewrite-spring:latest.release")))
+          .contains("io.moderne.recipe:rewrite-spring:latest.release");
+    }
+
+    @Test
+    void noWarningOnPinnedVersions() {
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          MAVEN_CENTRAL, singletonList("org.openrewrite.recipe:rewrite-spring:6.15.0")))
+          .isNull();
+    }
+
+    @Test
+    void noWarningOnUnrelatedArtifacts() {
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          MAVEN_CENTRAL, singletonList("com.example:my-recipes:latest.release")))
+          .isNull();
+    }
+
+    @Test
+    void noWarningWithoutRecipeArtifacts() {
+        assertThat(CodeGenomeProjectWarning.warningFor(MAVEN_CENTRAL, emptyList())).isNull();
+    }
+
+    @Test
+    void noWarningBehindAnInternalMirror() {
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          singletonList(URI.create("https://artifacts.internal.example.com/maven-central")),
+          singletonList("org.openrewrite.recipe:rewrite-spring:latest.release")))
+          .isNull();
+    }
+
+    @Test
+    void noWarningWhenTheCodeGenomeProjectIsConfigured() {
+        List<URI> repositories = asList(
+          URI.create("https://artifacts.codegenomeproject.org/maven"),
+          URI.create("https://repo.maven.apache.org/maven2/"));
+
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          repositories, singletonList("org.openrewrite.recipe:rewrite-spring:latest.release")))
+          .isNull();
+    }
+
+    @Test
+    void noWarningWhenRepositoriesAreNotVisibleToThePlugin() {
+        assertThat(CodeGenomeProjectWarning.warningFor(
+          emptyList(), singletonList("org.openrewrite.recipe:rewrite-spring:latest.release")))
+          .isNull();
+    }
+}

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/StaleRecipeArtifactTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/StaleRecipeArtifactTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.Issue
+import java.io.File
+
+@Issue("https://github.com/openrewrite/rewrite-gradle-plugin/issues/458")
+class StaleRecipeArtifactTest : GradleRunnerTest {
+
+    @Test
+    fun `warns when a dynamic recipe version resolves from Maven Central`(
+        @TempDir projectDir: File
+    ) {
+        gradleProject(projectDir) {
+            buildGradle(recipeDependency("org.openrewrite.recipe:rewrite-testing-frameworks:latest.release"))
+        }
+
+        val result = runGradle(projectDir, "rewriteDiscover")
+
+        assertThat(result.output)
+            .contains("org.openrewrite.recipe:rewrite-testing-frameworks:latest.release")
+            .contains("https://codegenomeproject.org/token")
+    }
+
+    @Test
+    fun `does not warn when the recipe version is pinned`(
+        @TempDir projectDir: File
+    ) {
+        gradleProject(projectDir) {
+            buildGradle(recipeDependency("org.openrewrite.recipe:rewrite-testing-frameworks:3.42.1"))
+        }
+
+        val result = runGradle(projectDir, "rewriteDiscover")
+
+        assertThat(result.output).doesNotContain("https://codegenomeproject.org/token")
+    }
+
+    private fun recipeDependency(coordinate: String) = """
+        plugins {
+            id("java")
+            id("org.openrewrite.rewrite")
+        }
+
+        repositories {
+            mavenLocal()
+            mavenCentral()
+            maven {
+                url = uri("https://central.sonatype.com/repository/maven-snapshots")
+            }
+        }
+
+        dependencies {
+            rewrite("$coordinate")
+        }
+    """
+}


### PR DESCRIPTION
- Fixes #458

## What

When the `rewrite` configuration asks for an OpenRewrite/Moderne recipe artifact with a **dynamic** version (`latest.release`, `1.+`, `[1.0,2.0)`, …) and the only repository that can serve it is the real Maven Central, the plugin now logs a warning pointing at the Code Genome Project:

```
These recipe artifacts resolve from Maven Central, which no longer receives new recipe releases:
    org.openrewrite.recipe:rewrite-testing-frameworks:latest.release
Newer recipe versions are published to the Code Genome Project; configure it in your repositories to stop resolving stale recipes.
See https://codegenomeproject.org/token for credentials and repository configuration.
```

Informational only — resolution is untouched and the build still succeeds.

## Acceptance criteria

| Criterion | How it's met |
| --- | --- |
| Warn when recipe artifacts resolve from Maven Central and a newer version is expected on CGP | A dynamic version served only by Maven Central is exactly the "silently stale" case |
| Warning links to the docs page for getting CGP credentials | Links to <https://codegenomeproject.org/token> |
| No warning through a configured repository, including an internal mirror | Only `repo.maven.apache.org` / `repo1.maven.org` / `repo2.maven.org` count as Maven Central; a mirror URL doesn't. A repository whose host contains `codegenome` suppresses the warning outright |
| No warning on explicitly pinned versions | Only dynamic version selectors are considered |

## Design notes / open questions

- **Detection is by declared repository, not by the repository an artifact actually came from.** Gradle's public `ResolutionResult` API exposes no repository origin (`ResolvedComponentResult` has no `getRepositoryName()`), and the plugin supports Gradle back to 4.10, so reaching into internals wasn't attractive. Declared-repository inspection is a heuristic, but it's the conservative direction: an unknown repository set (e.g. repositories declared in `settings.gradle` via `dependencyResolutionManagement`, where `project.getRepositories()` is empty) produces **no** warning rather than a false one.
- **The issue suggested keying off "the last version published to Maven Central".** I didn't hardcode a per-artifact version map — it needs upkeep on every artifact, and "dynamic version + Central-only" already identifies the same population without going stale itself. Happy to switch if the known-final-version list is preferable.
- **The plugin's own bundled `rewrite-core` et al. are not checked** — those are pinned by the plugin and move with a plugin upgrade. Only user-declared `rewrite` configuration dependencies are considered "recipe artifacts". Let me know if the bundled ones should warn too.
- **Message wording and the docs URL want a review.** `https://codegenomeproject.org/token` is the sign-in/build-configuration page; if there's a dedicated docs page for obtaining credentials, that's probably the better link.

## Testing

- `CodeGenomeProjectWarningTest` — unit tests over the detection rule (dynamic selectors, Moderne groups, pinned versions, unrelated groups, internal mirror, CGP configured, no visible repositories).
- `StaleRecipeArtifactTest` — TestKit functional tests asserting the warning shows up on `rewriteDiscover` for a `latest.release` recipe and stays quiet for a pinned one.