### PR TITLE
Pin `rewrite-docker` to `rewriteVersion`

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -101,7 +101,7 @@ configurations.named("testRuntimeOnly").configure {
 dependencies {
     "rewriteDependencies"(platform("org.openrewrite:rewrite-bom:$latest"))
     "rewriteDependencies"("org.openrewrite:rewrite-core")
-//    "rewriteDependencies"("org.openrewrite:rewrite-docker")
+    "rewriteDependencies"("org.openrewrite:rewrite-docker")
     "rewriteDependencies"("org.openrewrite:rewrite-hcl")
     "rewriteDependencies"("org.openrewrite:rewrite-java")
     "rewriteDependencies"("org.openrewrite:rewrite-java-25")

--- a/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/RewritePlugin.java
@@ -204,7 +204,7 @@ public class RewritePlugin implements Plugin<Project> {
         String rewriteVersion = extension.getRewriteVersion();
         return Arrays.asList(
                 deps.create("org.openrewrite:rewrite-core:" + rewriteVersion),
-//                deps.create("org.openrewrite:rewrite-docker:" + rewriteVersion),
+                deps.create("org.openrewrite:rewrite-docker:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-groovy:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-gradle:" + rewriteVersion),
                 deps.create("org.openrewrite:rewrite-hcl:" + rewriteVersion),


### PR DESCRIPTION
- Reverts d30af04, which commented out `rewrite-docker` shortly after #417 added it.

`rewrite-docker` is already on the resolved classpath transitively via `rewrite-polyglot` (runtime scope), and `OmniParser.defaultResourceParsers()` unconditionally constructs a `DockerParser` — so this does not turn Dockerfile parsing on, it was already happening. What it changes is the version: docker was floating on polyglot's pinned rewrite version while every other module tracks `extension.getRewriteVersion()`, so overriding `rewriteVersion` left docker behind.

Worth noting `rewrite-docker` was first published at 8.72.3, so explicitly setting `rewriteVersion` below that will now fail to resolve; `rewrite-java-25` already imposes a floor of 8.61.3, so this raises an existing constraint rather than introducing a new one.

Verified `generateVersionsProperties` now lists `rewrite-docker` at the same version as `rewrite-core`, and `RewriteDryRunTest` (TestKit, resolves the detached configuration end-to-end) passes.