### PR TITLE
Forward CGP artifact repository credentials for dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ concurrency:
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when the
+  # secrets are unset, which leaves the codegenome repository out of the build entirely.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ on:
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when the
+  # secrets are unset, which leaves the codegenome repository out of the build entirely.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
 
 jobs:
   release:

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -47,6 +47,26 @@ repositories {
             excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
         }
     }
+
+    val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull
+    val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull
+    if (!codegenomeUsername.isNullOrEmpty() && !codegenomePassword.isNullOrEmpty()) {
+        maven {
+            name = "codegenome"
+            url = uri("https://artifacts.codegenomeproject.org/maven")
+            credentials {
+                username = codegenomeUsername
+                password = codegenomePassword
+            }
+            // Declared after Maven Central and group-scoped, so an outage or expired token
+            // can't break resolution of anything CGP doesn't serve.
+            mavenContent {
+                includeGroupAndSubgroups("org.openrewrite")
+                includeGroupAndSubgroups("io.moderne")
+            }
+        }
+    }
+
     gradlePluginPortal()
     google()
 }


### PR DESCRIPTION
Ports [openrewrite/rewrite-github-actions@56b1b07](https://github.com/openrewrite/rewrite-github-actions/commit/56b1b0716b85610ece7277c940911a6c7d4799ea) to this repo. That commit was a two-line secrets forward because `rewrite-github-actions` delegates to `openrewrite/gh-automation`'s reusable workflows, which already map the secrets to `ORG_GRADLE_PROJECT_codegenome*` and rely on `rewrite-build-gradle-plugin`'s `RewriteDependencyRepositoriesPlugin` to declare the repository — this repo has neither, so both halves are ported by hand.

`ci.yml` and `publish.yml` set `ORG_GRADLE_PROJECT_codegenomeUsername`/`codegenomePassword` from the `CGP_ARTIFACTS_MAVEN_USERNAME`/`CGP_ARTIFACTS_MAVEN_TOKEN` secrets, and `plugin/build.gradle.kts` declares the `codegenome` Maven repo mirroring the convention plugin: after `mavenCentral()`, credentialed, group-scoped to `org.openrewrite`/`io.moderne`, and only registered when both credentials are non-empty.

The `cgp_aws_access_key_id`/`cgp_aws_secret_access_key` half of the upstream `publish.yml` change is deliberately omitted — those feed the `org.openrewrite.build.publish-cgp` convention plugin, which this repo doesn't apply.

Verified locally: `:plugin:dependencies --configuration compileClasspath` resolves cleanly, an init script dumping registered repos confirms `codegenome` lands in the right position, and `actionlint` passes on both workflows. The negative case (credentials unset ⇒ repo absent) was not observable locally since `~/.gradle/gradle.properties` already carries the credentials, so it rests on the `isNullOrEmpty` guard rather than an observed run.