### PR TITLE
Bump Kotlin plugin to 2.4.0 to match Gradle 9.7.0

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.*
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    id("org.jetbrains.kotlin.jvm") version "2.4.0"
     id("com.gradle.plugin-publish") version "latest.release"
     id("com.github.hierynomus.license") version "0.16.1"
     id("nebula.maven-apache-license")


### PR DESCRIPTION
CI on `main` broke after the Gradle wrapper update to 9.7.0: `:plugin:compileKotlin` fails because Gradle 9.7.0 ships `kotlin-stdlib`/`kotlin-reflect` 2.4.0 on the `gradleApi()` classpath, and the pinned Kotlin 2.2.0 compiler can only read metadata up to 2.3.0.

```
e: Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin.
   The actual metadata version is 2.4.0, but the compiler version 2.2.0 can read versions up to 2.3.0.
```

Bumping the Kotlin JVM plugin to 2.4.0 lines the compiler up with what Gradle embeds. Verified locally on Gradle 9.7.0: `:plugin:compileKotlin`, `build` (minus the test-kit suites) and the test compilation all succeed.