### PR TITLE
Resolve dependencies from CGP before Sonatype snapshots and Maven Central

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -30,27 +30,21 @@ gradlePlugin {
 }
 
 repositories {
-    if (!project.hasProperty("releasing")) {
+    val releasing = project.hasProperty("releasing")
+
+    if (!releasing) {
         mavenLocal {
             mavenContent {
                 excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
             }
-        }
-
-        maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots")
-        }
-    }
-
-    mavenCentral {
-        mavenContent {
-            excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
         }
     }
 
     val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull
     val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull
     if (!codegenomeUsername.isNullOrEmpty() && !codegenomePassword.isNullOrEmpty()) {
+        // CGP is the first publish target for both snapshots and releases, so consult it
+        // ahead of Sonatype and Maven Central; group-scoped to the artifacts it serves.
         maven {
             name = "codegenome"
             url = uri("https://artifacts.codegenomeproject.org/maven")
@@ -58,12 +52,28 @@ repositories {
                 username = codegenomeUsername
                 password = codegenomePassword
             }
-            // Declared after Maven Central and group-scoped, so an outage or expired token
-            // can't break resolution of anything CGP doesn't serve.
             mavenContent {
                 includeGroupAndSubgroups("org.openrewrite")
                 includeGroupAndSubgroups("io.moderne")
             }
+        }
+    }
+
+    if (!releasing) {
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots")
+            // Only consult the snapshots repo for groups that actually publish snapshots we consume,
+            // so a snapshots-repo outage can't break resolution of third-party releases.
+            mavenContent {
+                includeGroupAndSubgroups("org.openrewrite")
+                includeGroupAndSubgroups("io.moderne")
+            }
+        }
+    }
+
+    mavenCentral {
+        mavenContent {
+            excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
         }
     }
 


### PR DESCRIPTION
- Follow-up to #461, which added the `codegenome` repository to this repo's hand-rolled `repositories {}` block.

- `rewrite-build-gradle-plugin` [#206](https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/206) landed after #461 and reordered `RewriteDependencyRepositoriesPlugin` so CGP is consulted **before** the Sonatype snapshots repository and Maven Central. This repo can't apply that convention plugin, so its copy drifted: CGP was declared last, still carrying the "Declared after Maven Central and group-scoped" comment that #206 deleted.

This brings the copy back in line, so the ordering is mavenLocal → codegenome → Sonatype snapshots → Maven Central → plugin portal → google:

- Move the `codegenome` repository ahead of the snapshots repository and Maven Central, with the comment from #206.
- Group-scope the Sonatype snapshots repository to `org.openrewrite`/`io.moderne`, matching the convention plugin, so a snapshots-repo outage can't break resolution of third-party releases.
- Hoist `releasing` into a local, since it now gates two blocks.

Nearly every `org.openrewrite` coordinate here uses `latest.integration`/`latest.release`, and Gradle unions dynamic versions across repositories rather than stopping at the first hit, so this is not a change in which versions get selected today. It matters for fixed versions, and for artifacts CGP is the only publisher of once the Maven Central cutover completes.

Verified locally against Gradle 9.7.0 with an init script printing `:plugin`'s repositories in order:

| Invocation | Repositories |
| --- | --- |
| credentials set | mavenLocal, **codegenome**, snapshots, MavenRepo, plugin portal, google |
| `-PcodegenomeUsername= -PcodegenomePassword=` | mavenLocal, snapshots, MavenRepo, plugin portal, google — no `codegenome` |
| `-Preleasing` | **codegenome**, MavenRepo, plugin portal, google |

`./gradlew :plugin:compileKotlin :plugin:compileTestJava` succeeds with CGP first.