### PR TITLE
Include invalid value in recipe validation error log

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -1444,9 +1444,10 @@ public class DefaultProjectParser implements GradleProjectParser {
                 .flatMap(Collection::stream).collect(toList());
         if (!failedValidations.isEmpty()) {
             failedValidations.forEach(failedValidation -> logger.error(
-                    "Recipe validation error in {} for property {}: {}",
+                    "Recipe validation error in {} for property {} with invalid value {}: {}",
                     recipe.getName(),
                     failedValidation.getProperty(),
+                    failedValidation.getInvalidValue(),
                     failedValidation.getMessage(),
                     failedValidation.getException()));
             if (extension.getFailOnInvalidActiveRecipes()) {


### PR DESCRIPTION
Recipe validation failures now log the offending value alongside the property name and message, so users can see what was actually configured without having to cross-reference their build file.

`Validated.Invalid.getInvalidValue()` returns `Object`, so a null value formats as `null` rather than throwing.

- Matches openrewrite/rewrite-maven-plugin#1192.