### PR TITLE
Cut over to the Code Genome Project for publishing and org.openrewrite resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ jobs:
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
       - name: publish-snapshots
         if: github.event_name != 'pull_request'
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot :plugin:publishPluginMavenPublicationToSonatypeRepository -x test -x publishPlugins
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot :plugin:publishPluginMavenPublicationToCgpRepository -x test -x publishPlugins
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+          # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
+          # deprecation banner with a stack trace on every upload. Drop once Gradle ships
+          # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
+          AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
 
   notify:
     if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rewrite {
 }
 ```
 
-### Consuming latest snapshots from OSSRH
+### Consuming latest snapshots from the Code Genome Project
 
 To use the latest `-SNAPSHOT` of the `rewrite-gradle-plugin`, update your project's `settings.gradle.kts`:
 
@@ -54,7 +54,11 @@ pluginManagement {
     repositories {
         // ...
         maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            url = uri("https://artifacts.codegenomeproject.org/maven")
+            credentials {
+                username = "USERNAME"
+                password = "TOKEN"
+            }
         }
         // ...
         // you'll likely also need this if you don't have a pluginManagement section already:
@@ -63,6 +67,10 @@ pluginManagement {
     }
 }
 ```
+
+The Code Genome Project repository requires authentication. Sign in to the Code Genome Project to
+create a download token, then replace `USERNAME` with the email or username you signed in with and
+`TOKEN` with that token.
 
 The plugin can be consumed in your `build.gradle.kts`:
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ pluginManagement {
 }
 ```
 
-The Code Genome Project repository requires authentication. Sign in to the Code Genome Project to
-create a download token, then replace `USERNAME` with the email or username you signed in with and
-`TOKEN` with that token.
+The [Code Genome Project](https://codegenomeproject.org/) repository requires authentication.
+[Sign in to get a download token](https://codegenomeproject.org/token), then replace `USERNAME` with
+the email or username you signed in with and `TOKEN` with that token.
 
 The plugin can be consumed in your `build.gradle.kts`:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,6 @@ nexusPublishing {
     repositories {
         sonatype {
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("nebula.release") version "latest.release"
-    id("io.github.gradle-nexus.publish-plugin") version "latest.release"
     id("org.owasp.dependencycheck") version "latest.release" apply false
     id("nebula.maven-resolved-dependencies") version "latest.release" apply false
     id("nebula.maven-apache-license") version "latest.release" apply false
@@ -40,14 +39,6 @@ allprojects {
             module("com.google.collections:google-collections") {
                 replacedBy("com.google.guava:guava", "google-collections is part of guava")
             }
-        }
-    }
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
         }
     }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -40,11 +40,12 @@ repositories {
         }
     }
 
-    val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull
-    val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull
-    if (!codegenomeUsername.isNullOrEmpty() && !codegenomePassword.isNullOrEmpty()) {
-        // CGP is the first publish target for both snapshots and releases, so consult it
-        // ahead of Sonatype and Maven Central; group-scoped to the artifacts it serves.
+    val codegenomeUsername = providers.gradleProperty("codegenomeUsername").getOrElse("")
+    val codegenomePassword = providers.gradleProperty("codegenomePassword").getOrElse("")
+    val codegenomeConfigured = codegenomeUsername.isNotEmpty() && codegenomePassword.isNotEmpty()
+    if (codegenomeConfigured) {
+        // CGP is the only source of org.openrewrite and io.moderne artifacts; group-scoped to
+        // the artifacts it serves so an outage can't break resolution of third-party releases.
         maven {
             name = "codegenome"
             url = uri("https://artifacts.codegenomeproject.org/maven")
@@ -59,25 +60,25 @@ repositories {
         }
     }
 
-    if (!releasing) {
-        maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots")
-            // Only consult the snapshots repo for groups that actually publish snapshots we consume,
-            // so a snapshots-repo outage can't break resolution of third-party releases.
-            mavenContent {
-                includeGroupAndSubgroups("org.openrewrite")
-                includeGroupAndSubgroups("io.moderne")
+    mavenCentral {
+        mavenContent {
+            excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
+            if (codegenomeConfigured) {
+                excludeGroupAndSubgroups("org.openrewrite")
+                excludeGroupAndSubgroups("io.moderne")
             }
         }
     }
 
-    mavenCentral {
-        mavenContent {
-            excludeVersionByRegex(".+", ".+", ".+-rc-?[0-9]*")
+    // The plugin portal proxies Maven Central, so it needs the same exclusion to keep these groups on CGP
+    gradlePluginPortal {
+        if (codegenomeConfigured) {
+            (this as MavenArtifactRepository).content {
+                excludeGroupAndSubgroups("org.openrewrite")
+                excludeGroupAndSubgroups("io.moderne")
+            }
         }
     }
-
-    gradlePluginPortal()
     google()
 }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -81,6 +81,21 @@ repositories {
     google()
 }
 
+publishing {
+    repositories {
+        // Region-qualified host, else Gradle's S3 transport defaults to us-east-1 (the bucket is us-west-2).
+        maven {
+            name = "cgp"
+            url = uri("s3://codegenome-artifacts.s3.us-west-2.amazonaws.com/maven")
+            credentials(AwsCredentials::class) {
+                accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+                secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+                sessionToken = System.getenv("AWS_SESSION_TOKEN")
+            }
+        }
+    }
+}
+
 val latest = if (project.hasProperty("releasing")) {
     "latest.release"
 } else {


### PR DESCRIPTION
Completes the cutover to the Code Genome Project: snapshots publish there instead of Sonatype, nothing publishes to Sonatype or Maven Central at all, and `org.openrewrite`/`io.moderne` artifacts are no longer consumed from Maven Central.

## Publishing

- `plugin/build.gradle.kts` registers CGP's S3 bucket as a Maven publishing repository, mirroring [`org.openrewrite.build.publish-cgp`](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/src/main/java/org/openrewrite/gradle/RewriteCgpPublishPlugin.java) — this repo can't apply that plugin, since it wires nebula and `gradle-nexus.publish-plugin` directly. The host is region-qualified because Gradle's S3 transport otherwise defaults to `us-east-1`.
- `.github/workflows/ci.yml` publishes `:plugin:publishPluginMavenPublicationToCgpRepository` with the `CGP_AWS_*` org secrets, replacing the Sonatype and OSSRH signing credentials. The signing properties were dead already — no `signing` plugin is applied anywhere in this build.
- `build.gradle.kts` drops `io.github.gradle-nexus.publish-plugin` and its `nexusPublishing` block. **These were vestigial:** `org.openrewrite:plugin` was never on Maven Central (`repo1.maven.org` 404s for it), because releases go to the Gradle Plugin Portal via `publishPlugins` and nothing ever invoked `publishToSonatype`. `cgp` is now the only Maven publishing repository.

## Resolution

- Removes the `central.sonatype.com/repository/maven-snapshots` repository.
- Excludes `org.openrewrite` and `io.moderne` from both `mavenCentral` and `gradlePluginPortal` (which proxies Central) whenever CGP credentials are configured, so those groups resolve from CGP alone. This follows the `codegenomeConfigured` pattern from [`rewrite-build-gradle-plugin`](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/build.gradle.kts) — gating on credentials keeps fork PRs, which receive no secrets, building against Central.
- `mavenCentral` stays for third-party dependencies.

## Verification

Run locally with real CGP credentials, so the credentialed path was genuinely exercised rather than falling back to Central:

- Snapshot resolution: every `org.openrewrite` dependency resolves from CGP at `8.91.0-SNAPSHOT` with Central excluded, including the `org.openrewrite.gradle.tooling` subgroup.
- Release resolution (`-Preleasing`): `latest.release` resolves to `8.90.4` from CGP.
- Release task graph (`final publishPlugins --dry-run` against a throwaway local tag) is unchanged and contains no Sonatype step.
- All `*Sonatype*` tasks are gone; `publishPluginMavenPublicationToCgpRepository` resolves through jar → javadocJar → sourcesJar → POM → publish. The build still configures cleanly with no AWS credentials present.

## Worth flagging

- **Snapshots become credentialed.** `artifacts.codegenomeproject.org` returns 401 anonymously where the Sonatype snapshot repo did not, so anyone consuming `org.openrewrite:plugin:*-SNAPSHOT` without credentials needs a CGP download token. README updated accordingly.
- **The publish step is not exercised by PR CI** — it's gated on `github.event_name != 'pull_request'`, so the first real upload happens on merge to main.
- Now that `cgp` is the only publishing repository, `:plugin:publish` would also push the plugin marker (`publishRewritePluginMarkerMavenPublicationToCgpRepository`), which would make snapshots consumable via `plugins { id("org.openrewrite.rewrite") version "…-SNAPSHOT" }` and retire the `useModule` workaround in the README. Left out as out of scope; happy to add.