### PR TITLE
Drop non-existent classpath entries before parsing

### DIFF
--- a/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
+++ b/plugin/src/main/java/org/openrewrite/gradle/isolated/DefaultProjectParser.java
@@ -822,6 +822,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                         .map(File::toPath)
                         .map(Path::toAbsolutePath)
                         .map(Path::normalize)
+                        .filter(Files::exists)
                         .forEach(dependencyPaths::add);
             } catch (Exception e) {
                 logger.warn(
@@ -1321,6 +1322,7 @@ public class DefaultProjectParser implements GradleProjectParser {
                         .map(File::toPath)
                         .map(Path::toAbsolutePath)
                         .map(Path::normalize)
+                        .filter(Files::exists)
                         .distinct()
                         .collect(toList());
 


### PR DESCRIPTION
`RewriteRunTest.kotlinSourceGradle9` has been failing on `main` since the 2026-08-20 nightly, with `rewriteRun` reporting:

```
There were problems parsing src/main/kotlin/com/foo/A.kt
java.lang.IllegalStateException: diagnostic collector is not initialized
  org.jetbrains.kotlin.cli.common.CLIConfigurationKeysKt._get_diagnosticsCollector_$lambda$0(CLIConfigurationKeys.kt:110)
  org.jetbrains.kotlin.cli.CliDiagnosticReportingKt.report(CliDiagnosticReporting.kt:36)
  org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.findExistingRoot(KotlinCoreEnvironment.kt:395)
  org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.contentRootToVirtualFile(KotlinCoreEnvironment.kt:379)
  ...
```

Nothing changed in this repo; `rewrite-kotlin` snapshots moved to `kotlin-compiler-embeddable` 2.4.10. When `KotlinCoreEnvironment` hits a classpath root that doesn't exist it tries to report a warning, and on 2.4.10 that report throws because no diagnostics collector is configured — taking the whole file's parse down with it.

A source set's `runtimeClasspath` includes its own output directories, and those don't exist when the corresponding compile task is `NO-SOURCE` (`build/classes/java/main` and `build/resources/main` in the test project). Filtering non-existent entries out of the classpath we hand to the parsers avoids the crash; they carried no type information anyway.

Applied at both sites that build a classpath for `KotlinParser`.

`:plugin:test` passes locally (58 tests, 0 failures).