### PR TITLE
Honor DEPENDENCY_CHECK_FORMAT in the dependencyCheck config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ allprojects {
     configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
         analyzers.assemblyEnabled = false
         suppressionFile = "suppressions.xml"
+        format = System.getenv("DEPENDENCY_CHECK_FORMAT") ?: "HTML"
         nvd.apiKey = System.getenv("NVD_API_KEY")
         analyzers.centralEnabled = System.getenv("CENTRAL_ANALYZER_ENABLED").toBoolean()
         analyzers.ossIndex.username = System.getenv("OSSINDEX_USERNAME")


### PR DESCRIPTION
The nightly SOC2 scan in [moderneinc/dependency-vulnerability-reports](https://github.com/moderneinc/dependency-vulnerability-reports) runs `dependencyCheckAggregate` with `DEPENDENCY_CHECK_FORMAT=JSON` and then aggregates every `dependency-check-report.json` it finds into a daily issue.

That variable is read by `rewrite-build-gradle-plugin`, which most repos go through. This build applies `org.owasp.dependencycheck` directly and configures the extension itself, so it never saw the variable and fell back to the plugin's `HTML` default. The uploaded artifact contained only HTML, and the aggregation silently skipped it.

In [run 32725823454](https://github.com/moderneinc/dependency-vulnerability-reports/actions/runs/32725823454) the job logged, but did not report:

- CVE-2026-53914 across 24 `org.jetbrains.kotlin:*` jars, in both the root and `plugin` projects
- CVE-2020-29582 on `kotlin-reflect-1.6.10.jar`

The default stays `HTML`, so local `./gradlew dependencyCheckAnalyze` is unchanged; only the scan workflow sets the variable. Matches the idiom already used in [`rewrite-build-gradle-plugin/build.gradle.kts`](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/build.gradle.kts).

Verified `./gradlew tasks` configures cleanly.

Note for follow-up: this repo's `suppressions.xml` is an empty stub, so it does not consume the shared suppression set that `rewrite-build-gradle-plugin` stages for other repos. Once JSON lands, both CVEs above will surface in the daily report even though they are already triaged and suppressed indefinitely elsewhere (build-time-only Kotlin toolchain, no fixed release yet). They will need suppression entries here, or this repo should adopt the shared set.