### PR TITLE
Suppress CVE-2026-53914 and CVE-2020-29582 on the Kotlin toolchain jars

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,3 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2026-10-01Z">
+        <notes><![CDATA[
+            CVE-2026-53914 (GHSA-r937-wjx7-w2jp) is unsafe deserialization of untrusted Kotlin
+            build-cache metadata, allowing code execution. JetBrains, the CNA, scores it
+            MODERATE 6.7 (CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:H/I:L/A:L — local access, high
+            privileges, high attack complexity); NVD re-scored it 9.8 CRITICAL as
+            AV:N/AC:L/PR:N, which is what the scanner reports.
+            GHSA lists exactly one affected Maven package: org.jetbrains.kotlin:kotlin-gradle-plugin
+            < 2.4.20-Beta1. NVD instead encodes a single coarse cpe:2.3:a:jetbrains:kotlin < 2.4.20,
+            which matches every artifact under the org.jetbrains.kotlin group, so all 24 Kotlin jars
+            on this build's classpaths are flagged.
+            Provenance: only kotlin-stdlib:2.4.0 is on :plugin:runtimeClasspath. Every other flagged
+            jar (kotlin-compiler-embeddable, kotlin-build-tools-*, kotlin-daemon-*, kotlin-scripting-*,
+            kotlin-klib-commonizer-embeddable, kotlin-script-runtime, kotlin-tooling-core, kotlin-reflect)
+            resolves only on Kotlin Gradle plugin internal configurations — kotlinCompilerClasspath,
+            kotlinBuildToolsApiClasspath, kotlinKlibCommonizerClasspath, kotlinAbiValidationCompatClasspath,
+            kotlinCompilerPluginClasspath{Main,Test} — which are build-time only and are not published.
+            The version is dictated by the Kotlin Gradle plugin (2.4.0 here) and cannot be bumped
+            independently. As of 2026-08-24 Maven Central has no 2.4.20 release — <release> is
+            2.4.20-RC — so there is nothing to upgrade to yet. Re-evaluate once the toolchain
+            moves to 2.4.20+.
+            Added: 2026-08-24
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/.*@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. CVE-2020-29582 (GHSA-cqj8-47ch-rvvq, MODERATE 5.3) is insecure
+            permissions on temporary files, and both the advisory text ("In JetBrains Kotlin before
+            1.4.21") and GHSA scope it to org.jetbrains.kotlin:kotlin-stdlib <= 1.4.20, fixed in
+            1.4.21. NVD's CPE range is erroneously widened to
+            cpe:2.3:a:jetbrains:kotlin versionEndExcluding 2.1.0, which is why kotlin-reflect:1.6.10
+            matches here despite carrying the fix.
+            Provenance: kotlin-reflect:1.6.10 resolves on the Kotlin Gradle plugin's internal
+            kotlinCompilerClasspath, kotlinBuildToolsApiClasspath, kotlinKlibCommonizerClasspath and
+            kotlinAbiValidationCompatClasspath configurations, plus rewriteDependencies and
+            testRuntimeClasspath. It is not on runtimeClasspath and is not published.
+            The advisory is permanently scoped to Kotlin < 1.4.21, so the versions we resolve can
+            never become a true positive for this CVE; suppressed indefinitely.
+            Added: 2026-08-24
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-(stdlib|reflect).*@.*$</packageUrl>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
The root `suppressions.xml` is currently an empty stub, so this repo triages nothing — unlike repos that go through `rewrite-build-gradle-plugin` and inherit its shared suppression set. Both CVEs below are already suppressed there; these entries bring this repo in line.

Both are surfaced by the same mechanism: NVD encodes a single coarse `cpe:2.3:a:jetbrains:kotlin` range, which matches **every** artifact under the `org.jetbrains.kotlin` group regardless of which one actually contains the flaw.

### CVE-2026-53914 — time-boxed to 2026-10-01

[GHSA-r937-wjx7-w2jp](https://github.com/advisories/GHSA-r937-wjx7-w2jp), unsafe deserialization of Kotlin build-cache metadata.

- **Severity is contested.** JetBrains (the CNA) scores it MODERATE 6.7, `CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:H/I:L/A:L` — local access, high privileges, high attack complexity. NVD re-scored it 9.8 CRITICAL as `AV:N/AC:L/PR:N`, which is what the scanner reports.
- **Affected package, per GHSA:** `org.jetbrains.kotlin:kotlin-gradle-plugin < 2.4.20-Beta1` — and only that one. NVD's CPE is `cpe:2.3:a:jetbrains:kotlin` `versionEndExcluding 2.4.20`, hence all 24 Kotlin jars on this build's classpaths getting flagged.
- **Provenance.** Only `kotlin-stdlib:2.4.0` is on `:plugin:runtimeClasspath`. Every other flagged jar resolves solely on Kotlin Gradle plugin internal configurations — `kotlinCompilerClasspath`, `kotlinBuildToolsApiClasspath`, `kotlinKlibCommonizerClasspath`, `kotlinAbiValidationCompatClasspath`, `kotlinCompilerPluginClasspath{Main,Test}` — which are build-time only and not published. Confirmed with `./gradlew :plugin:dependencies`.
- **Why not remediate.** The version is dictated by the Kotlin Gradle plugin (2.4.0 here). As of 2026-08-24 Maven Central has no 2.4.20 release — `<release>` in `maven-metadata.xml` is `2.4.20-RC` — so there is nothing to upgrade to. Time-boxed rather than permanent so it lifts when the toolchain moves.

### CVE-2020-29582 — indefinite

[GHSA-cqj8-47ch-rvvq](https://github.com/advisories/GHSA-cqj8-47ch-rvvq), MODERATE 5.3, insecure temp-file permissions.

- Advisory text says "In JetBrains Kotlin **before 1.4.21**"; GHSA gives `org.jetbrains.kotlin:kotlin-stdlib <= 1.4.20`, **fixed in 1.4.21**.
- NVD's CPE range is erroneously widened to `versionEndExcluding 2.1.0`, which is the only reason `kotlin-reflect:1.6.10` matches — it already carries the fix.
- That jar resolves on the Kotlin plugin's internal classpaths plus `rewriteDependencies` and `testRuntimeClasspath`; not on `runtimeClasspath`.
- Permanently scoped to `< 1.4.21`, so the versions we resolve can never become a true positive for this CVE. Suppressed indefinitely, matching how `rewrite-build-gradle-plugin` treats it.

### Validation

- `xmllint --noout --schema dependency-suppression.1.3.xsd suppressions.xml` → validates.
- Each `packageUrl` regex checked against the exact purls the scan reported: 17/17 for CVE-2026-53914, and `kotlin-reflect@1.6.10` for CVE-2020-29582.

- Companion to #469, which makes this repo emit JSON so the scan aggregation stops silently dropping it. Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1155