### PR TITLE
Point TestKit test fixtures at the Code Genome Project

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -183,6 +183,22 @@ project.rootProject.tasks.getByName("postRelease").dependsOn(project.tasks.getBy
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // Hand the same Code Genome Project credentials to the builds TestKit launches, so they resolve
+    // the org.openrewrite versions this build pinned in versions.properties from where it got them.
+    // An argument provider without annotated inputs keeps the credentials out of the task's input
+    // fingerprint. Absent the properties, as on fork pull requests, the fixtures fall back to
+    // Maven Central plus Sonatype snapshots.
+    val codegenomeUsername = providers.gradleProperty("codegenomeUsername")
+    val codegenomePassword = providers.gradleProperty("codegenomePassword")
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        val username = codegenomeUsername.orNull
+        val password = codegenomePassword.orNull
+        if (username.isNullOrEmpty() || password.isNullOrEmpty()) {
+            emptyList()
+        } else {
+            listOf("-DcodegenomeUsername=$username", "-DcodegenomePassword=$password")
+        }
+    })
 }
 
 val gVP = tasks.register("generateVersionsProperties") {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -199,11 +199,9 @@ project.rootProject.tasks.getByName("postRelease").dependsOn(project.tasks.getBy
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
-    // Hand the same Code Genome Project credentials to the builds TestKit launches, so they resolve
-    // the org.openrewrite versions this build pinned in versions.properties from where it got them.
-    // An argument provider without annotated inputs keeps the credentials out of the task's input
-    // fingerprint. Absent the properties, as on fork pull requests, the fixtures fall back to
-    // Maven Central plus Sonatype snapshots.
+    // Hand the same credentials to the builds TestKit launches, so they resolve org.openrewrite from
+    // where this build did. An argument provider without annotated inputs keeps them out of the task
+    // input fingerprint.
     val codegenomeUsername = providers.gradleProperty("codegenomeUsername")
     val codegenomePassword = providers.gradleProperty("codegenomePassword")
     jvmArgumentProviders.add(CommandLineArgumentProvider {

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/GradleProjectSpec.kt
@@ -109,11 +109,7 @@ class GradleProjectSpec(
                     repositories {
                         gradlePluginPortal()
                         google()
-                        mavenLocal()
-                        mavenCentral()
-                        maven {
-                            url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                        }
+                        ${TestKitRepositories.declarations(24)}
                     }
                 }
             """.trimIndent()
@@ -136,11 +132,7 @@ class GradleProjectSpec(
                     repositories {
                         gradlePluginPortal()
                         google()
-                        mavenLocal()
-                        mavenCentral()
-                        maven {
-                            url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                        }
+                        ${TestKitRepositories.declarations(24)}
                         // jcenter is currently only required for AGP 3.*
                         jcenter()
                     }

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
@@ -37,6 +37,7 @@ internal object TestKitRepositories {
     private val username: String? = System.getProperty("codegenomeUsername")?.ifEmpty { null }
     private val password: String? = System.getProperty("codegenomePassword")?.ifEmpty { null }
 
+    /** Repository content filtering arrived in Gradle 5.1, and this suite still tests Gradle 4.10. */
     private val supportsContentFiltering: Boolean =
         GradleVersion.version(System.getProperty("org.openrewrite.test.gradleVersion", "8.0")) >=
                 GradleVersion.version("5.1")
@@ -50,9 +51,13 @@ internal object TestKitRepositories {
             url = uri("$SONATYPE_SNAPSHOTS_URL")
         }
         """.trimIndent()
-    } else {
-        // CGP goes ahead of Maven Central, so that Central is never asked for org.openrewrite artifacts.
+    } else if (supportsContentFiltering) {
+        // Scoped to the artifacts CGP serves, it can go ahead of Maven Central, which is then never
+        // asked for org.openrewrite at all.
         listOf("mavenLocal()", codeGenomeRepository(username, password), "mavenCentral()").joinToString("\n")
+    } else {
+        // Unscoped, it has to go last, or every third-party dependency would be looked up on CGP first.
+        listOf("mavenLocal()", "mavenCentral()", codeGenomeRepository(username, password)).joinToString("\n")
     }
 
     private fun codeGenomeRepository(username: String, password: String): String {

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle
+
+/**
+ * The repositories from which builds launched by TestKit resolve the `org.openrewrite` artifacts
+ * that `versions.properties` pins.
+ *
+ * When the Code Genome Project credentials reach the test JVM as system properties, which
+ * `plugin/build.gradle.kts` arranges from the `codegenomeUsername` and `codegenomePassword` Gradle
+ * properties, those builds resolve from CGP, the same place the main build resolves from. Without
+ * the credentials, as on fork pull requests, they fall back to Maven Central plus the Sonatype
+ * snapshots repository.
+ *
+ * `mavenLocal()` stays first either way, so a locally published `rewrite` build still wins.
+ */
+internal object TestKitRepositories {
+
+    private const val CODE_GENOME_URL = "https://artifacts.codegenomeproject.org/maven"
+    private const val SONATYPE_SNAPSHOTS_URL = "https://central.sonatype.com/repository/maven-snapshots"
+
+    private val username: String? = System.getProperty("codegenomeUsername")?.ifEmpty { null }
+    private val password: String? = System.getProperty("codegenomePassword")?.ifEmpty { null }
+
+    //language=groovy
+    private val DECLARATIONS: String = if (username == null || password == null) {
+        """
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = uri("$SONATYPE_SNAPSHOTS_URL")
+        }
+        """.trimIndent()
+    } else {
+        // No content filtering, as the repository content APIs postdate the oldest Gradle version tested here.
+        """
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url = uri("$CODE_GENOME_URL")
+            credentials {
+                username = ${username.asGroovyString()}
+                password = ${password.asGroovyString()}
+            }
+        }
+        """.trimIndent()
+    }
+
+    /**
+     * The repository declarations without an enclosing `repositories { }`, so that they can be dropped
+     * into a `dependencyResolutionManagement` block alongside other repositories.
+     */
+    fun declarations(indent: Int): String = DECLARATIONS.indentedForInterpolation(indent)
+
+    /**
+     * The declarations wrapped in a `repositories { }` block.
+     */
+    fun block(indent: Int): String =
+        ("repositories {\n" + DECLARATIONS.prependIndent("    ") + "\n}").indentedForInterpolation(indent)
+
+    /**
+     * Indents every line but the first by [indent] spaces, so that the result reads correctly when
+     * interpolated into a build script whose lines are indented that far.
+     */
+    private fun String.indentedForInterpolation(indent: Int) = replaceIndent(" ".repeat(indent)).trimStart()
+
+    /** A single quoted Groovy string, which unlike a double quoted one does not interpolate a `$` in a token. */
+    private fun String.asGroovyString() = "'" + replace("\\", "\\\\").replace("'", "\\'") + "'"
+}

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.gradle
 
+import org.gradle.util.GradleVersion
+
 /**
  * The repositories from which builds launched by TestKit resolve the `org.openrewrite` artifacts
  * that `versions.properties` pins.
@@ -35,6 +37,10 @@ internal object TestKitRepositories {
     private val username: String? = System.getProperty("codegenomeUsername")?.ifEmpty { null }
     private val password: String? = System.getProperty("codegenomePassword")?.ifEmpty { null }
 
+    private val supportsContentFiltering: Boolean =
+        GradleVersion.version(System.getProperty("org.openrewrite.test.gradleVersion", "8.0")) >=
+                GradleVersion.version("5.1")
+
     //language=groovy
     private val DECLARATIONS: String = if (username == null || password == null) {
         """
@@ -45,18 +51,29 @@ internal object TestKitRepositories {
         }
         """.trimIndent()
     } else {
-        // No content filtering, as the repository content APIs postdate the oldest Gradle version tested here.
-        """
-        mavenLocal()
-        mavenCentral()
-        maven {
-            url = uri("$CODE_GENOME_URL")
-            credentials {
-                username = ${username.asGroovyString()}
-                password = ${password.asGroovyString()}
-            }
+        // CGP goes ahead of Maven Central, so that Central is never asked for org.openrewrite artifacts.
+        listOf("mavenLocal()", codeGenomeRepository(username, password), "mavenCentral()").joinToString("\n")
+    }
+
+    private fun codeGenomeRepository(username: String, password: String): String {
+        val lines = mutableListOf(
+            "maven {",
+            """    url = uri("$CODE_GENOME_URL")""",
+            "    credentials {",
+            "        username = ${username.asGroovyString()}",
+            "        password = ${password.asGroovyString()}",
+            "    }"
+        )
+        if (supportsContentFiltering) {
+            // Everything else keeps coming from Maven Central; the regex avoids escapes Groovy rejects.
+            lines += listOf(
+                "    content {",
+                """        includeGroupByRegex("org[.]openrewrite.*")""",
+                "    }"
+            )
         }
-        """.trimIndent()
+        lines += "}"
+        return lines.joinToString("\n")
     }
 
     /**

--- a/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
@@ -18,16 +18,9 @@ package org.openrewrite.gradle
 import org.gradle.util.GradleVersion
 
 /**
- * The repositories from which builds launched by TestKit resolve the `org.openrewrite` artifacts
- * that `versions.properties` pins.
- *
- * When the Code Genome Project credentials reach the test JVM as system properties, which
- * `plugin/build.gradle.kts` arranges from the `codegenomeUsername` and `codegenomePassword` Gradle
- * properties, those builds resolve from CGP, the same place the main build resolves from. Without
- * the credentials, as on fork pull requests, they fall back to Maven Central plus the Sonatype
- * snapshots repository.
- *
- * `mavenLocal()` stays first either way, so a locally published `rewrite` build still wins.
+ * The repositories builds launched by TestKit resolve `org.openrewrite` artifacts from: the Code Genome
+ * Project when `plugin/build.gradle.kts` passed its credentials through as system properties, and Maven
+ * Central plus Sonatype snapshots when it could not, as on fork pull requests.
  */
 internal object TestKitRepositories {
 
@@ -37,7 +30,7 @@ internal object TestKitRepositories {
     private val username: String? = System.getProperty("codegenomeUsername")?.ifEmpty { null }
     private val password: String? = System.getProperty("codegenomePassword")?.ifEmpty { null }
 
-    /** Repository content filtering arrived in Gradle 5.1, and this suite still tests Gradle 4.10. */
+    // Repository content filtering arrived in Gradle 5.1, and this suite still tests Gradle 4.10.
     private val supportsContentFiltering: Boolean =
         GradleVersion.version(System.getProperty("org.openrewrite.test.gradleVersion", "8.0")) >=
                 GradleVersion.version("5.1")
@@ -52,11 +45,9 @@ internal object TestKitRepositories {
         }
         """.trimIndent()
     } else if (supportsContentFiltering) {
-        // Scoped to the artifacts CGP serves, it can go ahead of Maven Central, which is then never
-        // asked for org.openrewrite at all.
         listOf("mavenLocal()", codeGenomeRepository(username, password), "mavenCentral()").joinToString("\n")
     } else {
-        // Unscoped, it has to go last, or every third-party dependency would be looked up on CGP first.
+        // Unscoped, CGP has to go last, or every third-party dependency would be looked up there first.
         listOf("mavenLocal()", "mavenCentral()", codeGenomeRepository(username, password)).joinToString("\n")
     }
 
@@ -70,7 +61,6 @@ internal object TestKitRepositories {
             "    }"
         )
         if (supportsContentFiltering) {
-            // Everything else keeps coming from Maven Central; the regex avoids escapes Groovy rejects.
             lines += listOf(
                 "    content {",
                 """        includeGroupByRegex("org[.]openrewrite.*")""",
@@ -81,24 +71,15 @@ internal object TestKitRepositories {
         return lines.joinToString("\n")
     }
 
-    /**
-     * The repository declarations without an enclosing `repositories { }`, so that they can be dropped
-     * into a `dependencyResolutionManagement` block alongside other repositories.
-     */
+    /** The declarations without an enclosing `repositories { }`, for a `dependencyResolutionManagement` block. */
     fun declarations(indent: Int): String = DECLARATIONS.indentedForInterpolation(indent)
 
-    /**
-     * The declarations wrapped in a `repositories { }` block.
-     */
     fun block(indent: Int): String =
         ("repositories {\n" + DECLARATIONS.prependIndent("    ") + "\n}").indentedForInterpolation(indent)
 
-    /**
-     * Indents every line but the first by [indent] spaces, so that the result reads correctly when
-     * interpolated into a build script whose lines are indented that far.
-     */
+    // Indents every line but the first, so the result reads correctly interpolated at that indent.
     private fun String.indentedForInterpolation(indent: Int) = replaceIndent(" ".repeat(indent)).trimStart()
 
-    /** A single quoted Groovy string, which unlike a double quoted one does not interpolate a `$` in a token. */
+    // Single quoted, so that Groovy does not interpolate a `$` in a token.
     private fun String.asGroovyString() = "'" + replace("\\", "\\\\").replace("'", "\\'") + "'"
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDiscoverTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.REPOSITORIES
 import java.io.File
 
 class RewriteDiscoverTest : RewritePluginTest {
@@ -39,13 +40,7 @@ class RewriteDiscoverTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                        url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 dependencies {
                     rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:latest.release")

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteDryRunTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.openrewrite.Issue
 import org.openrewrite.gradle.condition.EnabledForGradleRange
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.REPOSITORIES
 import java.io.File
 
 @Suppress("GroovyUnusedAssignment")
@@ -65,13 +66,7 @@ class RewriteDryRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.gradle.SayHello", "org.openrewrite.java.format.AutoFormat")
@@ -102,13 +97,7 @@ class RewriteDryRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
             """
             )
             sourceSet("main") {
@@ -149,13 +138,7 @@ class RewriteDryRunTest : RewritePluginTest {
                 group = "org.example"
                 version = "1.0-SNAPSHOT"
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 kotlin {
                     jvmToolchain(8)
@@ -222,13 +205,7 @@ class RewriteDryRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
             """
             )
         }
@@ -358,13 +335,7 @@ class RewriteDryRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.FindSourceFiles")

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewritePluginTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
 import org.openrewrite.gradle.condition.EnabledForGradleRange
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.REPOSITORIES
 import java.io.File
 
 interface RewritePluginTest: GradleRunnerTest {
@@ -42,13 +43,7 @@ interface RewritePluginTest: GradleRunnerTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
                 """
             )
         }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/RewriteRunTest.kt
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
 import org.openrewrite.gradle.condition.DisabledForGradleRange
 import org.openrewrite.gradle.condition.EnabledForGradleRange
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.REPOSITORIES
+import org.openrewrite.gradle.fixtures.GradleFixtures.Companion.repositories
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
@@ -64,13 +66,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.java.format.AutoFormat")
@@ -120,13 +116,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.gradle.SayHello", "org.openrewrite.java.format.AutoFormat")
@@ -197,13 +187,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.gradle.SayHello", "org.openrewrite.java.format.AutoFormat")
@@ -297,13 +281,7 @@ class RewriteRunTest : RewritePluginTest {
                     exclusion("**/BTestClass.java")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 subprojects {
                     apply plugin: "java"
@@ -395,13 +373,7 @@ class RewriteRunTest : RewritePluginTest {
                     activeRecipe("org.openrewrite.ChangeFooToBar")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 subprojects {
                     apply plugin: "java"
@@ -463,13 +435,7 @@ class RewriteRunTest : RewritePluginTest {
                     activeRecipe("org.openrewrite.staticanalysis.EqualsAvoidsNull")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 dependencies {
                     rewrite("org.openrewrite.recipe:rewrite-static-analysis:latest.release")
@@ -537,13 +503,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("com.example.RenameSam")
@@ -589,13 +549,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.test.AddGradleWrapper")
@@ -651,13 +605,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 def foo() {}
                 class A {}
@@ -688,13 +636,7 @@ class RewriteRunTest : RewritePluginTest {
                 id("org.openrewrite.rewrite")
             }
 
-            repositories {
-                mavenLocal()
-                mavenCentral()
-                maven {
-                   url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                }
-            }
+            ${repositories(12)}
 
             def foo() {}
             class A {}
@@ -734,13 +676,7 @@ class RewriteRunTest : RewritePluginTest {
             settingsGradle(
                 """
                 dependencyResolutionManagement {
-                    repositories {
-                        mavenLocal()
-                        mavenCentral()
-                        maven {
-                           url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                        }
-                    }
+                    ${repositories(20)}
                 }
             """
             )
@@ -806,13 +742,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.java.format.AutoFormat")
@@ -872,13 +802,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.java.format.AutoFormat")
@@ -963,13 +887,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.test.FindA")
@@ -1034,13 +952,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.jetbrains.kotlin.jvm") version("2.2.0")
                     id("org.openrewrite.rewrite")
                 }
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
                 kotlin {
                     jvmToolchain(21)
                 }
@@ -1093,13 +1005,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.jetbrains.kotlin.jvm") version("1.9.20")
                     id("org.openrewrite.rewrite")
                 }
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
                 rewrite {
                     activeRecipe("org.openrewrite.test.FindString")
                 }
@@ -1168,13 +1074,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.java.format.AutoFormat")
@@ -1267,13 +1167,7 @@ class RewriteRunTest : RewritePluginTest {
                     plugins {
                         id("org.openrewrite.rewrite")
                     }
-                    repositories {
-                        mavenLocal()
-                        mavenCentral()
-                        maven {
-                           url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                        }
-                    }
+                    ${repositories(20)}
 
                     rewrite {
                         activeRecipe("com.example.TextToSam")
@@ -1324,13 +1218,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 sourceSets {
                     create("overlapping") {
@@ -1399,13 +1287,7 @@ class RewriteRunTest : RewritePluginTest {
                     id("org.openrewrite.rewrite")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                        url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("com.test.DeleteYamlKey")
@@ -1469,13 +1351,7 @@ class RewriteRunTest : RewritePluginTest {
                 id("org.openrewrite.rewrite")
             }
 
-            repositories {
-                mavenLocal()
-                mavenCentral()
-                maven {
-                    url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                }
-            }
+            ${repositories(12)}
 
             rewrite {
                 activeRecipe("org.openrewrite.gradle.FindDistributionUrl")
@@ -1532,13 +1408,7 @@ class RewriteRunTest : RewritePluginTest {
                 plugins {
                     id("org.openrewrite.rewrite")
                 }
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
             """
             )
         }
@@ -1579,13 +1449,7 @@ class RewriteRunTest : RewritePluginTest {
                     sourceCompatibility = JavaVersion.VERSION_17
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.test.AddJavaApplicationProperty")
@@ -1667,13 +1531,7 @@ class RewriteRunTest : RewritePluginTest {
                     }
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 rewrite {
                     activeRecipe("org.openrewrite.test.AddJavaApplicationProperty")
@@ -1735,13 +1593,7 @@ class RewriteRunTest : RewritePluginTest {
             )
             otherGradleScript(
                 "dependencies.gradle", """
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
                 dependencies {
                     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
                 }
@@ -1757,13 +1609,7 @@ class RewriteRunTest : RewritePluginTest {
             //language=groovy
             .isEqualTo(
                 """
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
                 dependencies {
                     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.0")
                 }
@@ -1797,13 +1643,7 @@ class RewriteRunTest : RewritePluginTest {
                     activeRecipe("org.openrewrite.test.FindLombokGetter")
                 }
 
-                repositories {
-                    mavenLocal()
-                    mavenCentral()
-                    maven {
-                       url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                    }
-                }
+                $REPOSITORIES
 
                 dependencies {
                     compileOnly("org.projectlombok:lombok:1.18.34")

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
@@ -15,25 +15,26 @@
  */
 package org.openrewrite.gradle.fixtures
 
+import org.openrewrite.gradle.TestKitRepositories
+
 class GradleFixtures {
     companion object {
-        //language=groovy
-        const val REPOSITORIES = """
-            repositories {
-                mavenLocal()
-                mavenCentral()
-                maven {
-                    url = uri("https://central.sonatype.com/repository/maven-snapshots")
-                }
-            }
-        """
+        /**
+         * The repositories every build launched by TestKit resolves `org.openrewrite` artifacts from,
+         * indented to sit in a build script whose lines are indented [indent] spaces.
+         */
+        fun repositories(indent: Int): String = TestKitRepositories.block(indent)
+
+        val REPOSITORIES: String = repositories(16)
 
         //language=groovy
-        const val REWRITE_BUILD_GRADLE = """
+        val REWRITE_BUILD_GRADLE = """
             plugins {
                 id("java")
                 id("org.openrewrite.rewrite")
             }
-        """ + REPOSITORIES
+
+            ${repositories(12)}
+        """
     }
 }

--- a/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
+++ b/plugin/src/test/kotlin/org/openrewrite/gradle/fixtures/GradleFixtures.kt
@@ -19,10 +19,7 @@ import org.openrewrite.gradle.TestKitRepositories
 
 class GradleFixtures {
     companion object {
-        /**
-         * The repositories every build launched by TestKit resolves `org.openrewrite` artifacts from,
-         * indented to sit in a build script whose lines are indented [indent] spaces.
-         */
+        // Rendered to sit in a build script whose lines are indented that many spaces.
         fun repositories(indent: Int): String = TestKitRepositories.block(indent)
 
         val REPOSITORIES: String = repositories(16)


### PR DESCRIPTION
Fixes #471.

The main build already resolves `org.openrewrite` from CGP, but the builds TestKit launches resolved the versions it pinned from Maven Central plus the Sonatype snapshots repository. That works only while `rewrite` dual-publishes; once it stops publishing snapshots to Sonatype, the pinned version exists in no repository the fixtures know about.

## What changed

- **Credentials reach the test JVMs.** `plugin/build.gradle.kts` passes `codegenomeUsername` / `codegenomePassword` to every `Test` task as system properties. It uses a `CommandLineArgumentProvider` with no annotated inputs, so the credentials stay out of the task input fingerprint. CI already exports both as `ORG_GRADLE_PROJECT_*`, so no workflow change was needed.
- **`GradleFixtures.REPOSITORIES` is credential-aware.** With the properties present it emits the credentialed CGP repository; without them it emits today's Maven Central plus Sonatype snapshots, which keeps fork pull requests building. `mavenLocal()` stays first either way, so a locally published `rewrite` build still wins.
- **Where the Gradle under test can content-filter (5.1+), CGP is scoped to `org[.]openrewrite.*` and goes ahead of Central.** Ordering it after Central left 234 requests in place as 404s in the first run on this branch. The Gradle 4.10 suite has no filtering API, so there CGP goes last instead; putting an unscoped credentialed repository first sent every third-party lookup through it and ran that suite 37% slower.
- **All 34 inline blocks now come from the fixture**, rendered at the call site's indent so the generated build scripts are byte-identical to what they were. The rendering lives in `TestKitRepositories` next to `GradleProjectSpec`, which lets the `settings.gradle` that `GradleProjectSpec` generates use it too. That was the last remaining Sonatype reference in the test tree.

## What the green run shows

Gradle's own resolution in the sub-builds now goes to CGP: 458 requests to `artifacts.codegenomeproject.org`, and the 11 remaining Sonatype snapshot requests all come from the main build's own `org.openrewrite.tools:jgit` and `rewrite-polyglot` dependencies, not from the fixtures.

Maven Central still sees 238 `org/openrewrite/` requests, down from 443, and they are no longer Gradle resolving the fixture repositories:

- 84 come from the Gradle 4.10 suite, where CGP is last, so Central is asked first and misses.
- The rest are the recipe tasks themselves. Inside `:rewriteRun` / `:rewriteDryRun`, OpenRewrite's own pom downloader probes Central for the same snapshots and 404s; it does not go through Gradle's repository content filters. The tasks succeed regardless, and this is untouched by the fixture change.
- The `latest.release` / `latest.integration` crawl also has to list versions on every repository, Central included.

## Verification

Locally with CGP credentials, `RewriteRunTest.gradleDependencyManagement`, which asserts the exact text of the generated `build.gradle`, passes; that confirms the rendered block matches at both indents and that the emitted repository DSL is valid. The rest of the suite hits Maven Central `HTTP 429` from my machine for third-party artifacts (AGP, Lombok, Checkstyle, `rewrite-testing-frameworks`), so those were left to CI, which is green.

Both long CI runs on this branch stalled for 47 and 64 minutes storing a build cache entry, on `community.develocity.cloud` connection timeouts. That is unrelated to this change; the per-suite times are in line with the baseline.

## Left out

The three fixtures that request recipe artifacts at `latest.release` / `latest.integration` still do. Pinning them would cut request volume sharply, as the issue notes, but it also freezes each one against a rewrite runtime that keeps moving, so it seemed worth a separate decision.