### PR TITLE
Let TestKit fixtures resolve io.moderne from the Code Genome Project

### DIFF
--- a/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
+++ b/plugin/src/main/kotlin/org/openrewrite/gradle/TestKitRepositories.kt
@@ -18,9 +18,9 @@ package org.openrewrite.gradle
 import org.gradle.util.GradleVersion
 
 /**
- * The repositories builds launched by TestKit resolve `org.openrewrite` artifacts from: the Code Genome
- * Project when `plugin/build.gradle.kts` passed its credentials through as system properties, and Maven
- * Central plus Sonatype snapshots when it could not, as on fork pull requests.
+ * The repositories builds launched by TestKit resolve `org.openrewrite` and `io.moderne` artifacts from: the
+ * Code Genome Project when `plugin/build.gradle.kts` passed its credentials through as system properties, and
+ * Maven Central plus Sonatype snapshots when it could not, as on fork pull requests.
  */
 internal object TestKitRepositories {
 
@@ -63,7 +63,7 @@ internal object TestKitRepositories {
         if (supportsContentFiltering) {
             lines += listOf(
                 "    content {",
-                """        includeGroupByRegex("org[.]openrewrite.*")""",
+                """        includeGroupByRegex("(org[.]openrewrite|io[.]moderne).*")""",
                 "    }"
             )
         }


### PR DESCRIPTION
## Background / problem

The scheduled ci run [#33002073829](https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/33002073829) failed 39 of 58 TestKit tests, all with `Could not find io.moderne:jsonrpc:1.0.13`, required by `org.openrewrite:rewrite-core:8.92.0-SNAPSHOT:20260826.175419-1`. Gradle only searched `~/.m2` and Maven Central for it.

This plugin declares no `io.moderne` dependency of its own. `jsonrpc` is the only `io.moderne` artifact in the run and it arrives transitively: `rewrite-core` declares `implementation("io.moderne:jsonrpc:latest.release")` and ships it as a `runtime` dependency in its POM, because the `org.openrewrite.rpc` package (`RewriteRpc`, `RewriteRpcProcess` and the `Parse`, `Print`, `Visit`, `Generate` request types) uses it as the JSON-RPC transport to out-of-process language servers. Every consumer of `rewrite-core` pulls it in whether or not it uses RPC, and the TestKit builds resolve `rewrite-core` when `rewriteDryRun`, `rewriteRun` and `rewriteDiscover` build their recipe classpath.

Two things then lined up. `moderneinc/jsonrpc` cut 1.0.13 earlier today, its first release since it stopped publishing to Maven Central, so the artifact exists only on the Code Genome Project while Central stops at 1.0.12. Today's `rewrite-core` snapshot therefore pins 1.0.13. Meanwhile #472 pointed the TestKit fixtures at CGP but scoped that repository with `includeGroupByRegex("org[.]openrewrite.*")`. `io.moderne` falls outside the filter, so the fixture builds never ask CGP for jsonrpc. The push run on the same commit was green only because the snapshot at that time still pinned 1.0.12.

## Solution

Widen the CGP content filter in `TestKitRepositories` to `(org[.]openrewrite|io[.]moderne).*`, which is the same pair of groups `plugin/build.gradle.kts` already routes to CGP for the main build. The fallback declarations for builds without credentials are unchanged.

## Test plan

- [x] `:plugin:compileKotlin` locally
- [ ] ci on this branch, which has CGP credentials, resolves `jsonrpc:1.0.13` in the TestKit builds
