### PR TITLE
Publish releases to the Code Genome Project as well as the plugin portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,27 +31,6 @@ jobs:
         with:
           develocity-access-key: ${{ env.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
-      - name: publish-candidate
-        if: contains(github.ref, '-rc.')
-        run: |
-          ./gradlew \
-            -Preleasing \
-            -Prelease.disableGitChecks=true \
-            -Prelease.useLastTag=true \
-            -Dgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} \
-            -Dgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} \
-            candidate \
-            publishPlugins \
-            :plugin:publishPluginMavenPublicationToCgpRepository
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-west-2
-          # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
-          # deprecation banner with a stack trace on every upload. Drop once Gradle ships
-          # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
-          AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
-
       - name: publish-release
         if: (!contains(github.ref, '-rc.'))
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,16 @@ jobs:
             -Dgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} \
             -Dgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} \
             candidate \
-            publishPlugins
+            publishPlugins \
+            :plugin:publishPluginMavenPublicationToCgpRepository
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+          # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
+          # deprecation banner with a stack trace on every upload. Drop once Gradle ships
+          # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
+          AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
 
       - name: publish-release
         if: (!contains(github.ref, '-rc.'))
@@ -53,4 +62,13 @@ jobs:
             -Dgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} \
             -Dgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} \
             final \
-            publishPlugins
+            publishPlugins \
+            :plugin:publishPluginMavenPublicationToCgpRepository
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
+          # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
+          # deprecation banner with a stack trace on every upload. Drop once Gradle ships
+          # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
+          AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true


### PR DESCRIPTION
## Why v7.40.0 is missing from CGP

- The CGP cutover in #467 switched `ci.yml`'s snapshot step from
`publishPluginMavenPublicationToSonatypeRepository` to
`...ToCgpRepository`, but never touched `publish.yml`. Tagged releases have
only ever run `final publishPlugins`.

The [v7.40.0 release job](https://github.com/openrewrite/rewrite-gradle-plugin/actions/runs/32998135546)
confirms it — the task list ends at:

```
> Task :plugin:publishPlugins
> Task :postRelease
> Task :final
BUILD SUCCESSFUL in 54s
```

No `publishPluginMavenPublicationToCgpRepository`, so the artifact went to the
Gradle Plugin Portal and nothing was uploaded to
`s3://codegenome-artifacts/maven`. Hence the empty
`org/openrewrite/plugin/` on artifacts.codegenomeproject.org. Nothing failed;
the step was simply never asked to run.

## Fix

Adds `:plugin:publishPluginMavenPublicationToCgpRepository` and the
`CGP_AWS_*` credentials to both the candidate and release steps, mirroring
what `ci.yml` already does for snapshots.

## Backfilling 7.40.0

This only fixes releases from here on. 7.40.0 itself still needs a one-off
upload — either a local run with the CGP AWS credentials:

```
./gradlew -Preleasing -Prelease.useLastTag=true \
  :plugin:publishPluginMavenPublicationToCgpRepository
```

or cutting v7.40.1 once this merges. Re-running the existing tag's workflow
won't help: it would use the workflow file as of that tag, and `publishPlugins`
would fail on an already-published version.