### PR TITLE
Stop publishing to the Gradle Plugin Portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
       - name: publish-snapshots
         if: github.event_name != 'pull_request'
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot :plugin:publishPluginMavenPublicationToCgpRepository -x test -x publishPlugins
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot :plugin:publishPluginMavenPublicationToCgpRepository -x test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,7 @@ jobs:
             -Preleasing \
             -Prelease.disableGitChecks=true \
             -Prelease.useLastTag=true \
-            -Dgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} \
-            -Dgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} \
             final \
-            publishPlugins \
             :plugin:publishPluginMavenPublicationToCgpRepository
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
 <!-- Keep the gap above this line, otherwise they won't render correctly! -->
 [![ci](https://github.com/openrewrite/rewrite-gradle-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/openrewrite/rewrite-gradle-plugin/actions/workflows/ci.yml)
-[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org.openrewrite/plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/org.openrewrite.rewrite)
 [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans)
 [![Contributing Guide](https://img.shields.io/badge/Contributing-Guide-informational)](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md)
 </div>
@@ -37,9 +36,11 @@ rewrite {
 }
 ```
 
-### Consuming latest snapshots from the Code Genome Project
+### Consuming from the Code Genome Project
 
-To use the latest `-SNAPSHOT` of the `rewrite-gradle-plugin`, update your project's `settings.gradle.kts`:
+The plugin is published to the [Code Genome Project](https://codegenomeproject.org/) rather than the Gradle
+Plugin Portal, since it resolves `org.openrewrite` artifacts that are only available there. To consume a
+release or `-SNAPSHOT` of the `rewrite-gradle-plugin`, update your project's `settings.gradle.kts`:
 
 ```kts
 pluginManagement {
@@ -68,7 +69,7 @@ pluginManagement {
 }
 ```
 
-The [Code Genome Project](https://codegenomeproject.org/) repository requires authentication.
+The Code Genome Project repository requires authentication.
 [Sign in to get a download token](https://codegenomeproject.org/token), then replace `USERNAME` with
 the email or username you signed in with and `TOKEN` with that token.
 
@@ -76,8 +77,8 @@ The plugin can be consumed in your `build.gradle.kts`:
 
 ```kts
 plugins {
-    id("org.openrewrite.rewrite") version "X.Y.Z-SNAPSHOT"
-    // or resolved dynamically to absolute latest:
+    id("org.openrewrite.rewrite") version "X.Y.Z"
+    // or resolved dynamically to the absolute latest snapshot:
     id("org.openrewrite.rewrite") version "latest.integration"
 }
 ```

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -6,6 +6,8 @@ import java.util.*
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.4.0"
+    // We no longer publish to the plugin portal, but this plugin still supplies the sources and
+    // javadoc jars that go into the Code Genome Project publication.
     id("com.gradle.plugin-publish") version "latest.release"
     id("com.github.hierynomus.license") version "0.16.1"
     id("nebula.maven-apache-license")
@@ -194,8 +196,6 @@ dependencies {
         }
     }
 }
-
-project.rootProject.tasks.getByName("postRelease").dependsOn(project.tasks.getByName("publishPlugins"))
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -6,8 +6,7 @@ import java.util.*
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.4.0"
-    // We no longer publish to the plugin portal, but this plugin still supplies the sources and
-    // javadoc jars that go into the Code Genome Project publication.
+    // Not for the portal; this supplies the sources and javadoc jars in the CGP publication.
     id("com.gradle.plugin-publish") version "latest.release"
     id("com.github.hierynomus.license") version "0.16.1"
     id("nebula.maven-apache-license")


### PR DESCRIPTION
The plugin resolves `rewrite-bom` and the rest of `org.openrewrite` from the Code Genome Project, so a portal-published plugin isn't usable on its own anyway.

- Drop the `postRelease` → `publishPlugins` wiring, and `publishPlugins` plus the `gradle.publish.key`/`secret` inputs from the release workflow.
- Drop the now-unneeded `-x publishPlugins` from the snapshot CI job.
- README: remove the plugin portal badge (it would freeze at the last portal release) and reword the CGP section to cover releases, not just snapshots.

`com.gradle.plugin-publish` stays applied — it's what supplies the sources and javadoc jars in the CGP publication.

Note that CGP still only receives the `pluginMaven` publication, not `rewritePluginMarkerMaven`, so consumers do need the `pluginManagement.resolutionStrategy.eachPlugin` / `useModule` block the README documents. If we'd rather have plain `plugins { id("org.openrewrite.rewrite") version "..." }` work off CGP, switching the workflows to `publishAllPublicationsToCgpRepository` would do it — happy to add that here or in a follow-up.